### PR TITLE
Wrap product search sorting select in label

### DIFF
--- a/packages/web-components/src/search/components/product-search-sorting.ts
+++ b/packages/web-components/src/search/components/product-search-sorting.ts
@@ -56,7 +56,9 @@ export class ProductSearchSorting extends LitElement {
     render() {
         const localization = getRelewiseUISearchOptions()?.localization?.sortingButton;
         return html`
-           <span class="rw-label" part="label">${localization?.sortBy ?? 'Sort by:'}</span> <select @change=${this.setSelectedValue} class="rw-select rw-border" part="select">
+            <label class="rw-label-wrapper">
+                <span class="rw-label" part="label">${localization?.sortBy ?? 'Sort by:'}</span>
+                <select @change=${this.setSelectedValue} class="rw-select rw-border" part="select">
                 ${Object.keys(SortingEnum).map((item) => {
             return html`
                         <option value=${item} ?selected=${this.selectedOption === item}>
@@ -64,14 +66,20 @@ export class ProductSearchSorting extends LitElement {
                         </option>
                     `;
         })}
-            </select>
+                </select>
+            </label>
         `;
     }
 
     static styles = [theme, css`
+        .rw-label-wrapper {
+            display: inline-flex;
+            align-items: center;
+        }
+
         .rw-select {
             font-family: var(--font);
-           
+
             padding: var(--relewise-product-search-sorting-padding, .5em);
 
             font-weight: var(--relewise-button-text-font-weight, 600);
@@ -88,7 +96,7 @@ export class ProductSearchSorting extends LitElement {
             color: var(--relewise-button-text-color, #333);
             margin-right: 0.2em;
         }
-        
+
         select:focus {
             outline: none;
         }


### PR DESCRIPTION
## Summary
- wrap the product search sorting select with a label so the localized "Sort by" text is exposed as the form control's name
- add a flex wrapper style to keep the label text and select aligned after the markup change

## Testing
- npm run test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68caa3540b2c832ca566ee7c1a6ff7e7