### PR TITLE
Add alt attribute to product tile images

### DIFF
--- a/packages/web-components/src/components/product-tile.ts
+++ b/packages/web-components/src/components/product-tile.ts
@@ -56,7 +56,7 @@ export class ProductTile extends LitElement {
     renderTileContent(product: ProductResult) {
         return html`
             ${(product.data)
-                ? html`<div class="rw-image-container"><img class="rw-object-cover" src=${product.data[`relewise-demo-store.myshopify.com_ImageUrls`].value.$values[0]} /></div>`
+                ? html`<div class="rw-image-container"><img class="rw-object-cover" src=${product.data[`relewise-demo-store.myshopify.com_ImageUrls`].value.$values[0]} alt=${this.getProductImageAlt(product)} /></div>`
                 : nothing
             }
             <div class='rw-information-container'>
@@ -70,6 +70,12 @@ export class ProductTile extends LitElement {
             }
                 </div>
             </div>`;
+    }
+
+    private getProductImageAlt(product: ProductResult): string {
+        const altText = product.displayName ?? product.variant?.displayName ?? '';
+
+        return altText ?? '';
     }
 
     static styles = [


### PR DESCRIPTION
## Summary
- add an alt attribute to the product tile image using the product name when available
- add a fallback helper to supply variant names or an empty string when the display name is missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68caa3636c14832c94dd967d22e3aa04