### PR TITLE
Fix icon slot name in button component

### DIFF
--- a/packages/web-components/src/components/button.ts
+++ b/packages/web-components/src/components/button.ts
@@ -20,7 +20,7 @@ export class Button extends LitElement {
                     ${this.buttonText ? html`
                         <span class="rw-button-text">${this.buttonText}</span>
                     ` : nothing}
-                    <span class="rw-button-icon"><slot slot="icon"></slot></span>
+                    <span class="rw-button-icon"><slot name="icon"></slot></span>
             </button>
         `;
     }


### PR DESCRIPTION
## Summary
- update the button component's icon slot to use the `name` attribute so slotted icon content renders correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68caa3715c88832cbc0dbf750815baf3