### PR TITLE
Ensure search bar input has accessible name

### DIFF
--- a/packages/web-components/src/search/components/search-bar.ts
+++ b/packages/web-components/src/search/components/search-bar.ts
@@ -42,16 +42,17 @@ export class SearchBar extends LitElement {
     render() {
         return html`
         <div class="rw-search-bar rw-border" part="input">
-            <input 
+            <input
                 id="search-input"
                 autocomplete="off"
                 class="rw-search-bar-input"
                 type="text"
                 placeholder=${this.placeholder ?? 'Search'}
+                aria-label=${this.placeholder ?? 'Search'}
                 .value=${this.term}
                 @keydown=${this.handleKeyEvent}
                 @input=${(e: InputEvent) => this.setSearchTerm((e.target as HTMLInputElement).value)}
-                @focus=${() => this.setSearchBarInFocus(true)} 
+                @focus=${() => this.setSearchBarInFocus(true)}
                 @blur=${() => this.setSearchBarInFocus(false)}>
             ${this.term ?
                 html`


### PR DESCRIPTION
## Summary
- ensure the search bar input exposes an accessible name by mirroring the placeholder into aria-label so screen readers announce it

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68caa37417fc832cae70b3a29811eb8a