### PR TITLE
Ensure facet value part exports correctly

### DIFF
--- a/packages/web-components/src/search/components/facets/facets.ts
+++ b/packages/web-components/src/search/components/facets/facets.ts
@@ -60,7 +60,7 @@ export class Facets extends LitElement {
             return html`
                 <relewise-checklist-ranges-object-value-facet
                     part="container"
-                    exportparts="title, input, label, hits"
+                    exportparts="title, input, label, value, hits"
                     style="${isLast ? 'border-bottom: 0; padding-bottom: 0;' : ''}"
                     .label=${label}
                     .result=${facetResult}
@@ -75,7 +75,7 @@ export class Facets extends LitElement {
                 <relewise-checklist-number-value-facet
                     .label=${label}    
                     part="container"
-                    exportparts="title, input, label, hits"
+                    exportparts="title, input, label, value, hits"
                     style="${isLast ? 'border-bottom: 0; padding-bottom: 0;' : ''}"
                     .result=${facetResult}
                     class=${styling}>
@@ -89,7 +89,7 @@ export class Facets extends LitElement {
                 <relewise-checklist-object-value-facet 
                     .label=${label}
                     part="container"
-                    exportparts="title, input, label, hits"
+                    exportparts="title, input, label, value, hits"
                     style="${isLast ? 'border-bottom: 0; padding-bottom: 0;' : ''}"
                     .result=${facetResult}
                     class=${styling}>
@@ -102,7 +102,7 @@ export class Facets extends LitElement {
                 <relewise-checklist-boolean-value-facet
                     .label=${label}
                     part="container"
-                    exportparts="title, input, label, hits"
+                    exportparts="title, input, label, value, hits"
                     style="${isLast ? 'border-bottom: 0; padding-bottom: 0;' : ''}"
                     .result=${facetResult}
                     class=${styling}>
@@ -115,7 +115,7 @@ export class Facets extends LitElement {
                 <relewise-checklist-string-value-facet
                     .label=${label}
                     part="container"
-                    exportparts="title, input, label, hits"
+                    exportparts="title, input, label, value, hits"
                     style="${isLast ? 'border-bottom: 0; padding-bottom: 0;' : ''}"
                     .result=${facetResult}
                     class=${styling}>

--- a/packages/web-components/src/search/product-search.ts
+++ b/packages/web-components/src/search/product-search.ts
@@ -315,7 +315,7 @@ export class ProductSearch extends LitElement {
             <div class="result-container">
                 ${this.products.length > 0 && this.searchResult?.facets ? html`
                     <relewise-facets
-                        exportparts="container: facet-container, title: facet-title, input: facet-input, label: facet-value, hits: facet-hits"
+                        exportparts="container: facet-container, title: facet-title, input: facet-input, label: facet-label, value: facet-value, hits: facet-hits"
                         .labels=${this.facetLabels}
                         .facetResult=${this.searchResult?.facets}
                         class="rw-facets">


### PR DESCRIPTION
## Summary
- include the facet value part in relewise-product-search's export mapping so it can be targeted via ::part selectors
- re-export the value part from checklist facet wrappers to align with the parts defined in the base facet template

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68caa36bcac8832ca5e713e93fb933b0