### PR TITLE
Add JSX typings for web components

### DIFF
--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,3 +1,5 @@
+import type { RelewiseIntrinsicElements } from './jsx';
+
 export * from './components';
 export * from './recommendations';
 export * from './helpers';
@@ -12,3 +14,16 @@ export * from './search';
 export * from './theme';
 export * from './targetedSearchConfigurations';
 export * from './targetedRecommendationConfigurations';
+export type {
+    RelewiseElementName,
+    StyleLike,
+    RelewiseElementProps,
+    RelewiseIntrinsicElements,
+    RelewiseJSXIntrinsicElements,
+} from './jsx';
+
+declare global {
+    namespace JSX {
+        interface IntrinsicElements extends RelewiseIntrinsicElements {}
+    }
+}

--- a/packages/web-components/src/jsx.ts
+++ b/packages/web-components/src/jsx.ts
@@ -1,0 +1,24 @@
+export {};
+
+export type RelewiseElementName = Extract<keyof HTMLElementTagNameMap, `relewise-${string}`>;
+
+export type StyleLike = string | Partial<CSSStyleDeclaration> | Record<string, string | number | null | undefined>;
+
+export type RelewiseElementProps<K extends RelewiseElementName> = Partial<HTMLElementTagNameMap[K]> & {
+    class?: string;
+    className?: string;
+    part?: string;
+    slot?: string;
+    style?: StyleLike;
+    children?: unknown;
+    ref?: unknown;
+    key?: string | number;
+} & {
+    [attribute: string]: unknown;
+};
+
+export type RelewiseIntrinsicElements = {
+    [K in RelewiseElementName]: RelewiseElementProps<K>;
+};
+
+export type RelewiseJSXIntrinsicElements = RelewiseIntrinsicElements;


### PR DESCRIPTION
## Summary
- add shared JSX typing utilities that map Relewise custom elements to their Lit element classes
- augment the package index to export the typings and extend the global JSX namespace for the components

## Testing
- npm run build:types

------
https://chatgpt.com/codex/tasks/task_b_68cab76ced488328b05219859ea3c0f5