### PR TITLE
feat: add tile field mapping attributes

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -1209,6 +1209,49 @@ The builder is a type exposed from the [relewise-sdk-javascript](https://github.
 
 For more examples and information about relevance modifiers visit the official [docs](https://docs.relewise.com/).
 
+## Tile field mapping
+Product and content tiles use Relewise standard fields and common data keys by default. If your dataset stores display fields under different data keys, set attributes on the tile to point the default rendering at those keys.
+
+These attributes only affect the built-in tile rendering. If you provide `templates.product` or `templates.content`, your custom template remains fully responsible for rendering.
+
+### Product tile attributes
+- **image-data-key** (Optional, *Default ImageUrl*): Data key used for the product image.
+- **image-base-url** (Optional): Prepended to relative image paths.
+- **url-data-key** (Optional, *Default Url*): Data key used for the product link.
+- **display-name-data-key** (Optional): Data key used for the displayed product name. Falls back to `product.displayName`.
+- **description-data-key** (Optional): Data key used for product description text. No description is shown by default.
+- **sales-price-data-key** (Optional): Data key used for the sales price. Falls back to `product.salesPrice`.
+- **list-price-data-key** (Optional): Data key used for the list price. Falls back to `product.listPrice`.
+
+```html
+<relewise-product-tile
+    image-data-key="PrimaryImage"
+    image-base-url="https://cdn.example.com"
+    url-data-key="ProductUrl"
+    display-name-data-key="CardTitle"
+    description-data-key="ShortDescription"
+    sales-price-data-key="CardSalesPrice"
+    list-price-data-key="CardListPrice">
+</relewise-product-tile>
+```
+
+### Content tile attributes
+- **image-data-key** (Optional, *Default ImageUrl*): Data key used for the content image.
+- **image-base-url** (Optional): Prepended to relative image paths.
+- **url-data-key** (Optional, *Default Url*): Data key used for the content link.
+- **display-name-data-key** (Optional): Data key used for the displayed content name. Falls back to `content.displayName`.
+- **description-data-key** (Optional, *Default Summary*): Data key used for content description text.
+
+```html
+<relewise-content-tile
+    image-data-key="HeroImage"
+    image-base-url="https://cdn.example.com"
+    url-data-key="ContentUrl"
+    display-name-data-key="CardTitle"
+    description-data-key="Excerpt">
+</relewise-content-tile>
+```
+
 ## Template overwriting
 It is possible to overwrite the template used for rendering products and/or content. This is done using [lit templating](https://lit.dev/docs/templates/overview/).
 When the template is overwritten, the corresponding tile skips attaching default CSS styles on the tile, so your template has full control over layout and presentation.

--- a/packages/web-components/src/components/content-tile.ts
+++ b/packages/web-components/src/components/content-tile.ts
@@ -15,6 +15,21 @@ export class ContentTile extends LitElement {
     @property({ type: Object })
     private user: User | null = null;
 
+    @property({ attribute: 'image-data-key' })
+    imageDataKey: string = 'ImageUrl';
+
+    @property({ attribute: 'image-base-url' })
+    imageBaseUrl: string | null = null;
+
+    @property({ attribute: 'url-data-key' })
+    urlDataKey: string = 'Url';
+
+    @property({ attribute: 'display-name-data-key' })
+    displayNameDataKey: string | null = null;
+
+    @property({ attribute: 'description-data-key' })
+    descriptionDataKey: string = 'Summary';
+
     // Override Lit's shadow root creation and only attach default styles when no template override exists.
     protected createRenderRoot(): HTMLElement | DocumentFragment {
         const root = super.createRenderRoot();
@@ -64,7 +79,7 @@ export class ContentTile extends LitElement {
             return html`${markup}`;
         }
 
-        const url = this.content.data && 'Url' in this.content.data ? this.content.data['Url'].value ?? '' : null;
+        const url = this.getContentDataValue(this.content, this.urlDataKey) ?? null;
 
         const engagementSettings = settings.userEngagement?.content;
 
@@ -89,8 +104,9 @@ export class ContentTile extends LitElement {
     }
 
     renderTileContent(content: ContentResult) {
-        const image = content.data && 'ImageUrl' in content.data ? content.data['ImageUrl'].value : null;
-        const summary = content.data && 'Summary' in content.data ? content.data['Summary'].value : null;
+        const image = this.resolveImageUrl(this.getContentDataValue(content, this.imageDataKey));
+        const displayName = this.getContentDataValue(content, this.displayNameDataKey) ?? content.displayName;
+        const summary = this.getContentDataValue(content, this.descriptionDataKey);
 
         return html`
             <div class="rw-image-container">
@@ -99,7 +115,7 @@ export class ContentTile extends LitElement {
                 : nothing}
             </div>
             <div class='rw-information-container'>
-                <h5 class='rw-display-name'>${content.displayName}</h5>
+                <h5 class='rw-display-name'>${displayName}</h5>
                 ${summary ? html`<p class="rw-summary">${summary}</p>` : nothing}
             </div>`;
     }
@@ -108,6 +124,22 @@ export class ContentTile extends LitElement {
         const altText = content.displayName ?? '';
 
         return altText ?? '';
+    }
+
+    private getContentDataValue(content: ContentResult, key: string | null) {
+        if (!key || !content.data || !(key in content.data)) {
+            return null;
+        }
+
+        return content.data[key].value ?? null;
+    }
+
+    private resolveImageUrl(image: unknown): unknown {
+        if (!image || !this.imageBaseUrl || typeof image !== 'string' || /^https?:\/\//.test(image) || image.startsWith('//')) {
+            return image;
+        }
+
+        return `${this.imageBaseUrl.replace(/\/$/, '')}/${image.replace(/^\//, '')}`;
     }
 
     static defaultStyles = [

--- a/packages/web-components/src/components/product-tile.ts
+++ b/packages/web-components/src/components/product-tile.ts
@@ -16,6 +16,27 @@ export class ProductTile extends LitElement {
     @property({ type: Object })
     private user: User | null = null;
 
+    @property({ attribute: 'image-data-key' })
+    imageDataKey: string = 'ImageUrl';
+
+    @property({ attribute: 'image-base-url' })
+    imageBaseUrl: string | null = null;
+
+    @property({ attribute: 'url-data-key' })
+    urlDataKey: string = 'Url';
+
+    @property({ attribute: 'display-name-data-key' })
+    displayNameDataKey: string | null = null;
+
+    @property({ attribute: 'description-data-key' })
+    descriptionDataKey: string | null = null;
+
+    @property({ attribute: 'sales-price-data-key' })
+    salesPriceDataKey: string | null = null;
+
+    @property({ attribute: 'list-price-data-key' })
+    listPriceDataKey: string | null = null;
+
     // Override Lit's shadow root creation and only attach default styles when no template override exists.
     protected createRenderRoot(): HTMLElement | DocumentFragment {
         const root = super.createRenderRoot();
@@ -66,7 +87,7 @@ export class ProductTile extends LitElement {
             return html`${markup}`;
         }
 
-        const url = this.product.data && 'Url' in this.product.data ? this.product.data['Url'].value ?? '' : null;
+        const url = this.getProductDataValue(this.product, this.urlDataKey) ?? null;
 
         const engagementSettings = settings.userEngagement?.product;
 
@@ -91,18 +112,24 @@ export class ProductTile extends LitElement {
     }
 
     renderTileContent(product: ProductResult) {
+        const image = this.resolveImageUrl(this.getProductDataValue(product, this.imageDataKey));
+        const displayName = this.getProductDataValue(product, this.displayNameDataKey) ?? product.displayName;
+        const description = this.getProductDataValue(product, this.descriptionDataKey);
+        const salesPrice = this.getProductDataValue(product, this.salesPriceDataKey) ?? product.salesPrice;
+        const listPrice = this.getProductDataValue(product, this.listPriceDataKey) ?? product.listPrice;
         return html`
-            ${(product.data && 'ImageUrl' in product.data)
-                ? html`<div class="rw-image-container"><img class="rw-object-cover" src=${product.data['ImageUrl'].value} alt=${this.getProductImageAlt(product)} /></div>`
+            ${image
+                ? html`<div class="rw-image-container"><img class="rw-object-cover" src=${image} alt=${this.getProductImageAlt(product)} /></div>`
                 : nothing
             }
             <div class='rw-information-container'>
-                <h5 class='rw-display-name'>${product.displayName}</h5>
+                <h5 class='rw-display-name'>${displayName}</h5>
+                ${description ? html`<p class="rw-description">${description}</p>` : nothing}
                 <div class='rw-price'>
-                    <span>${formatPrice(product.salesPrice)}</span>
+                    <span>${formatPrice(salesPrice)}</span>
 
-                    ${(product.salesPrice && product.listPrice && product.listPrice !== product.salesPrice)
-                ? html`<span class='rw-list-price'>${formatPrice(product.listPrice)}</span>`
+                    ${(salesPrice && listPrice && listPrice !== salesPrice)
+                ? html`<span class='rw-list-price'>${formatPrice(listPrice)}</span>`
                 : nothing
             }
                 </div>
@@ -113,6 +140,22 @@ export class ProductTile extends LitElement {
         const altText = product.variant?.displayName ?? product.displayName ?? '';
 
         return altText ?? '';
+    }
+
+    private getProductDataValue(product: ProductResult, key: string | null) {
+        if (!key || !product.data || !(key in product.data)) {
+            return null;
+        }
+
+        return product.data[key].value ?? null;
+    }
+
+    private resolveImageUrl(image: unknown): unknown {
+        if (!image || !this.imageBaseUrl || typeof image !== 'string' || /^https?:\/\//.test(image) || image.startsWith('//')) {
+            return image;
+        }
+
+        return `${this.imageBaseUrl.replace(/\/$/, '')}/${image.replace(/^\//, '')}`;
     }
 
     static defaultStyles = [
@@ -201,6 +244,13 @@ export class ProductTile extends LitElement {
             font-weight: 400;
             color: var(--relewise-list-price-color, #bbb);
             margin: var(--relewise-list-price-margin, 0em 0em 0em 0.5em);
+        }
+
+        .rw-description {
+            color: var(--relewise-description-color, #666);
+            font-size: var(--relewise-description-font-size, 0.9em);
+            line-height: var(--relewise-description-line-height, 1.2);
+            margin: var(--relewise-description-margin, 0.5em 0em 0em 0em);
         }
 
     `];

--- a/packages/web-components/tests/tileFieldMapping.test.ts
+++ b/packages/web-components/tests/tileFieldMapping.test.ts
@@ -1,0 +1,161 @@
+import { assert, fixture, fixtureCleanup, html } from '@open-wc/testing';
+import { ContentResult, ProductResult } from '@relewise/client';
+import { html as litHtml } from 'lit';
+import { initializeRelewiseUI } from '../src';
+import { mockRelewiseOptions } from './util/mockRelewiseUIOptions';
+
+suite('tile field mapping', () => {
+    setup(() => {
+        initializeRelewiseUI(mockRelewiseOptions()).useRecommendations();
+    });
+
+    teardown(() => {
+        fixtureCleanup();
+        window.relewiseUIOptions = undefined!;
+    });
+
+    test('product tile uses configured data keys for default rendering', async () => {
+        const product = {
+            displayName: 'Default product name',
+            rank: 1,
+            salesPrice: 10,
+            listPrice: 15,
+            data: {
+                CustomImage: dataValue('/images/product.jpg'),
+                CustomUrl: dataValue('/products/custom'),
+                CustomName: dataValue('Custom product name'),
+                CustomDescription: dataValue('Custom product description'),
+                CustomSalesPrice: dataValue(20),
+                CustomListPrice: dataValue(25),
+            },
+        } as ProductResult;
+
+        const el = await fixture(html`
+            <relewise-product-tile
+                .product=${product}
+                image-data-key="CustomImage"
+                image-base-url="https://cdn.example.com"
+                url-data-key="CustomUrl"
+                display-name-data-key="CustomName"
+                description-data-key="CustomDescription"
+                sales-price-data-key="CustomSalesPrice"
+                list-price-data-key="CustomListPrice">
+            </relewise-product-tile>
+        `);
+
+        const anchor = el.shadowRoot!.querySelector('a')!;
+        const image = el.shadowRoot!.querySelector('img')!;
+
+        assert.equal(anchor.getAttribute('href'), '/products/custom');
+        assert.equal(image.getAttribute('src'), 'https://cdn.example.com/images/product.jpg');
+        assert.include(el.shadowRoot!.textContent!, 'Custom product name');
+        assert.include(el.shadowRoot!.textContent!, 'Custom product description');
+        assert.include(el.shadowRoot!.textContent!, '20');
+        assert.include(el.shadowRoot!.textContent!, '25');
+    });
+
+    test('product tile keeps existing defaults when data key attributes are absent', async () => {
+        const product = {
+            displayName: 'Default product name',
+            rank: 1,
+            salesPrice: 10,
+            listPrice: 15,
+            data: {
+                ImageUrl: dataValue('data:image/gif;base64,R0lGODlhAQABAAAAACw='),
+                Url: dataValue('/products/default'),
+            },
+        } as ProductResult;
+
+        const el = await fixture(html`
+            <relewise-product-tile .product=${product}></relewise-product-tile>
+        `);
+
+        assert.equal(el.shadowRoot!.querySelector('a')!.getAttribute('href'), '/products/default');
+        assert.equal(el.shadowRoot!.querySelector('img')!.getAttribute('src'), 'data:image/gif;base64,R0lGODlhAQABAAAAACw=');
+        assert.include(el.shadowRoot!.textContent!, 'Default product name');
+    });
+
+    test('content tile uses configured data keys for default rendering', async () => {
+        const content = {
+            displayName: 'Default content name',
+            rank: 1,
+            data: {
+                CustomImage: dataValue('/images/content.jpg'),
+                CustomUrl: dataValue('/content/custom'),
+                CustomName: dataValue('Custom content name'),
+                CustomDescription: dataValue('Custom content description'),
+            },
+        } as ContentResult;
+
+        const el = await fixture(html`
+            <relewise-content-tile
+                .content=${content}
+                image-data-key="CustomImage"
+                image-base-url="https://cdn.example.com"
+                url-data-key="CustomUrl"
+                display-name-data-key="CustomName"
+                description-data-key="CustomDescription">
+            </relewise-content-tile>
+        `);
+
+        const anchor = el.shadowRoot!.querySelector('a')!;
+        const image = el.shadowRoot!.querySelector('img')!;
+
+        assert.equal(anchor.getAttribute('href'), '/content/custom');
+        assert.equal(image.getAttribute('src'), 'https://cdn.example.com/images/content.jpg');
+        assert.include(el.shadowRoot!.textContent!, 'Custom content name');
+        assert.include(el.shadowRoot!.textContent!, 'Custom content description');
+    });
+
+    test('content tile keeps existing default summary rendering when description data key is absent', async () => {
+        const content = {
+            displayName: 'Default content name',
+            rank: 1,
+            data: {
+                Summary: dataValue('Default summary'),
+            },
+        } as ContentResult;
+
+        const el = await fixture(html`
+            <relewise-content-tile .content=${content}></relewise-content-tile>
+        `);
+
+        assert.include(el.shadowRoot!.textContent!, 'Default content name');
+        assert.include(el.shadowRoot!.textContent!, 'Default summary');
+    });
+
+    test('product template override still controls rendering', async () => {
+        initializeRelewiseUI({
+            ...mockRelewiseOptions(),
+            templates: {
+                product: product => litHtml`<div class="custom-template">${product.displayName}</div>`,
+            },
+        }).useRecommendations();
+
+        const product = {
+            displayName: 'Template product',
+            rank: 1,
+            data: {
+                CustomName: dataValue('Mapped product'),
+            },
+        } as ProductResult;
+
+        const el = await fixture(html`
+            <relewise-product-tile
+                .product=${product}
+                display-name-data-key="CustomName">
+            </relewise-product-tile>
+        `);
+
+        assert.include(el.shadowRoot!.textContent!, 'Template product');
+        assert.notInclude(el.shadowRoot!.textContent!, 'Mapped product');
+    });
+});
+
+function dataValue(value: unknown) {
+    return {
+        type: 'String',
+        value,
+        isCollection: false,
+    };
+}


### PR DESCRIPTION
https://trello.com/c/lSAoYt5D/20837-full-page-search-add-product-content-tile-field-mapping

## Summary

Adds configurable field mapping attributes to the existing product and content tiles.

This is part of the full-page search UI Components work, but does not add the full-page search component yet. The goal is to make the existing reusable tiles flexible enough for future full-search rendering without introducing separate product/content card components.

## Changes

### Product tile

Adds optional attributes to `relewise-product-tile`:

- `image-data-key`, default `ImageUrl`
- `image-base-url`
- `url-data-key`, default `Url`
- `display-name-data-key`, fallback `product.displayName`
- `description-data-key`, optional, renders no description when absent
- `sales-price-data-key`, fallback `product.salesPrice`
- `list-price-data-key`, fallback `product.listPrice`

Existing default behavior is preserved when the new attributes are not provided.

### Content tile

Adds optional attributes to `relewise-content-tile`:

- `image-data-key`, default `ImageUrl`
- `image-base-url`
- `url-data-key`, default `Url`
- `display-name-data-key`, fallback `content.displayName`
- `description-data-key`, default `Summary`

Existing default behavior is preserved when the new attributes are not provided.

### Other

- Adds relative image URL support through `image-base-url`.
- Keeps `templates.product` and `templates.content` as full rendering overrides.
- Adds focused tests for product/content field mapping and template override behavior.
- Documents the new tile attributes in the README.