### PR TITLE
Codex/full search products tab

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -592,12 +592,12 @@ useSearch({
         universalSearch: {
             close: 'Close',
             emptyState: 'Start typing to search.',
-            noTabsConfigured: 'No universal-search tabs configured.',
+            noEntitiesConfigured: 'No universal-search entities configured.',
             tabsLabel: 'Search result tabs',
             products: {
                 tab: 'Products',
                 resultsFor: 'Search results for',
-                resultsTitle: 'Product Results',
+                resultsTitle: 'Products',
                 result: 'product',
                 results: 'products',
                 noResults: 'No products found.',
@@ -632,7 +632,7 @@ useSearch({
 ```
 
 #### Universal Search
-This component renders a universal-search modal that can be opened by a custom trigger. The products tab can be enabled through `useSearch({ universalSearch })` and reuses the existing product search configuration for facets, sorting, filters, relevance modifiers, selected properties, and target overrides.
+This component renders a universal-search modal that can be opened by a custom trigger. Product search can be enabled through `useSearch({ universalSearch: { entities } })` and reuses the existing product search configuration for facets, sorting, filters, relevance modifiers, selected properties, and target overrides.
 
 ```ts
 useSearch({
@@ -646,7 +646,7 @@ useSearch({
         .addRelevance()
         .addSalesPriceAscending(),
     universalSearch: {
-        tabs: {
+        entities: {
             products: {
                 pageSize: 16,
             },
@@ -665,7 +665,7 @@ useSearch({
 
 The component reads the existing `rw-term` URL parameter when it is connected, but it does not automatically open from URL state.
 
-When the products tab is configured, it renders product results with `relewise-product-tile`. Product rendering can therefore be overridden through the existing `initializeRelewiseUI({ templates: { product } })` template option. Additional universal-search tabs for product categories and content will be added separately.
+When the product entity is configured, it renders product results with `relewise-product-tile`. Product rendering can therefore be overridden through the existing `initializeRelewiseUI({ templates: { product } })` template option. Additional universal-search entities for product categories and content will be added separately.
 
 The current products tab uses load-more behavior. Additional pagination modes are not part of the initial products tab implementation.
 
@@ -1484,3 +1484,4 @@ This component sends a [track brand view](https://docs.relewise.com/docs/develop
 - **brand-id**:
     
     The id of the brand that has been viewed.
+

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -592,6 +592,17 @@ useSearch({
         universalSearch: {
             close: 'Close',
             emptyState: 'Start typing to search.',
+            noTabsConfigured: 'No universal-search tabs configured.',
+            tabsLabel: 'Search result tabs',
+            products: {
+                tab: 'Products',
+                resultsFor: 'Search results for',
+                resultsTitle: 'Product Results',
+                result: 'product',
+                results: 'products',
+                noResults: 'No products found.',
+                error: 'Could not load products.',
+            },
         },
         searchBar: {
             placeholder: 'Search',

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -579,9 +579,9 @@ useSearch({
             save: 'Save',
             showLess: 'Show Less',
             showMore: 'Show More',
-            toggle: 'Filter',
+            filter: 'Filter',
             yes: 'Yes',
-            no: 'No'
+            no: 'No',
         },
         loadMoreButton: {
             loadMore: 'Hent flere!',
@@ -611,12 +611,12 @@ useSearch({
         searchResults: {
             noResults: 'No products found',
             showAllResults: 'Show all results',
-            result: "Result";
-            results: "Results";
+            result: 'Result',
+            results: 'Results',
         },
         sortingButton: {
             sorting: 'sorting',
-            sortBy: "Sort by:"
+            sortBy: 'Sort by:',
             alphabeticalAscending: 'a - z',
             alphabeticalDescending: 'z - a',
             brandAscending: 'brand a - z',

--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -621,11 +621,26 @@ useSearch({
 ```
 
 #### Universal Search
-This component renders a universal-search modal that can be opened by a custom trigger. In this initial version, it provides modal state and search term URL synchronization only. Product, content, category, and recommendation result orchestration will be added separately.
+This component renders a universal-search modal that can be opened by a custom trigger. The products tab can be enabled through `useSearch({ universalSearch })` and reuses the existing product search configuration for facets, sorting, filters, relevance modifiers, selected properties, and target overrides.
 
 ```ts
 useSearch({
-    universalSearch: {},
+    facets: {
+        product(builder) {
+            builder.addFacet(f => f.addBrandFacet(), { heading: 'Brand' });
+        },
+    },
+    sorting: sorting => sorting
+        .clear()
+        .addRelevance()
+        .addSalesPriceAscending(),
+    universalSearch: {
+        tabs: {
+            products: {
+                pageSize: 16,
+            },
+        },
+    },
 });
 ```
 
@@ -638,6 +653,10 @@ useSearch({
 ```
 
 The component reads the existing `rw-term` URL parameter when it is connected, but it does not automatically open from URL state.
+
+When the products tab is configured, it renders product results with `relewise-product-tile`. Product rendering can therefore be overridden through the existing `initializeRelewiseUI({ templates: { product } })` template option. Additional universal-search tabs for product categories and content will be added separately.
+
+The current products tab uses load-more behavior. Additional pagination modes are not part of the initial products tab implementation.
 
 ##### Attributes
 

--- a/packages/web-components/UNIVERSAL_SEARCH_UI_COMPONENTS_PLAN.md
+++ b/packages/web-components/UNIVERSAL_SEARCH_UI_COMPONENTS_PLAN.md
@@ -720,6 +720,7 @@ Tasks:
   - CSS parts and variables
 - Add URL term read/write using `rw-term`.
 - Add initial termless view placeholder.
+- Add `localization.universalSearch` for modal-owned text.
 - Do not auto-open from `rw-term` in this phase; prefill only.
 - Do not add tab placeholders in this phase.
 
@@ -744,6 +745,7 @@ Tasks:
 - Render `relewise-product-tile`.
 - Support existing load-more behavior.
 - Support zero-result product tab state.
+- Add `localization.universalSearch.products` for product-tab-owned labels and state text.
 
 Acceptance:
 

--- a/packages/web-components/UNIVERSAL_SEARCH_UI_COMPONENTS_PLAN.md
+++ b/packages/web-components/UNIVERSAL_SEARCH_UI_COMPONENTS_PLAN.md
@@ -1,6 +1,6 @@
 # Universal Search UI Components Plan
 
-Last updated: 2026-06-26
+Last updated: 2026-06-30
 
 ## Purpose
 
@@ -634,7 +634,7 @@ Avoid adding components that simply duplicate current tiles/facets/sorting with 
 
 | Existing piece | Reuse | Notes |
 | --- | --- | --- |
-| `relewise-search-bar` | Direct reuse | Full-search controls URL/state itself. |
+| `relewise-search-bar` | Direct reuse | Universal Search controls URL/state itself. |
 | `relewise-product-tile` | Direct reuse | Custom product rendering uses existing `templates.product`. |
 | `relewise-content-tile` | Direct reuse | Custom content rendering uses existing `templates.content`. |
 | `relewise-facets` | Reuse after generalization | Must support content-compatible facet result shapes; scoped URL state belongs with the universal-search orchestrator if needed. |
@@ -742,7 +742,7 @@ Tasks:
 - Use existing `facets.product`.
 - Use existing product sorting builder and target overrides.
 - Render `relewise-product-tile`.
-- Support pagination/load more.
+- Support existing load-more behavior.
 - Support zero-result product tab state.
 
 Acceptance:
@@ -750,6 +750,8 @@ Acceptance:
 - Product facets/sorting match current product search config.
 - Shopify-style target config can be applied through a `target` attribute or equivalent.
 - Product cards are fully overridable through `templates.product`.
+- Tabs remain hidden before a search term exists.
+- Other pagination modes can be considered later, but are not part of this phase.
 
 ### PR 5: Product Categories And Content Tabs
 

--- a/packages/web-components/UNIVERSAL_SEARCH_UI_COMPONENTS_PLAN.md
+++ b/packages/web-components/UNIVERSAL_SEARCH_UI_COMPONENTS_PLAN.md
@@ -63,7 +63,7 @@ initializeRelewiseUI({ ... }).useSearch({
         .addRelevance()
         .addSalesPriceAscending(),
     universalSearch: {
-        tabs: {
+        entities: {
             products: {},
             productCategories: {},
             content: {},
@@ -75,7 +75,7 @@ initializeRelewiseUI({ ... }).useSearch({
 The exact `universalSearch` type should be finalized in the first implementation PR, but the principle is fixed:
 
 - Existing product `facets`, product `sorting`, filters, relevance modifiers, target overrides, selected properties, and templates stay authoritative.
-- `universalSearch` adds modal behavior, tab behavior, input-assist behavior, empty/no-result recommendations, layout defaults, and tab enablement.
+- `universalSearch` adds modal behavior, result-entity behavior, input-assist behavior, empty/no-result recommendations, layout defaults, and result-tab rendering.
 - Product result rendering delegates to `relewise-product-tile`.
 - Content result rendering delegates to `relewise-content-tile`.
 - Product/content custom field rendering is handled through existing `templates.product` and `templates.content`.
@@ -502,7 +502,7 @@ Proposed starting shape:
 
 ```ts
 export interface UniversalSearchOptions {
-    tabs?: UniversalSearchTabsOptions;
+    entities?: UniversalSearchEntitiesOptions;
     behavior?: UniversalSearchBehaviorOptions;
     inputAssist?: UniversalSearchInputAssistOptions;
     recommendations?: UniversalSearchRecommendationOptions;
@@ -513,10 +513,10 @@ Providing `universalSearch` opts in to registering and using the universal-searc
 
 Keep styling primarily in CSS variables and parts, not JavaScript configuration.
 
-### Tabs
+### Entities
 
 ```ts
-export interface UniversalSearchTabsOptions {
+export interface UniversalSearchEntitiesOptions {
     products?: UniversalSearchTabOptions;
     productCategories?: UniversalSearchTabOptions;
     content?: UniversalSearchTabOptions;
@@ -529,7 +529,7 @@ export interface UniversalSearchTabOptions {
 
 Notes:
 
-- Providing a tab option enables that tab. Omit a tab to disable it.
+- Providing an entity option enables that result type. Omit an entity to disable it.
 - Product tab uses existing `facets.product` and existing `sorting`.
 - Content facets can use `facets.content` once added.
 - Content/category sorting needs separate config if included.
@@ -738,7 +738,7 @@ Ship universal-search product tab using existing product search configuration.
 
 Tasks:
 
-- Add products tab with batched/universal-search request orchestration.
+- Add product entity result tab with universal-search request orchestration.
 - Use shared product search request helper.
 - Use existing `facets.product`.
 - Use existing product sorting builder and target overrides.
@@ -752,7 +752,7 @@ Acceptance:
 - Product facets/sorting match current product search config.
 - Shopify-style target config can be applied through a `target` attribute or equivalent.
 - Product cards are fully overridable through `templates.product`.
-- Tabs remain hidden before a search term exists.
+- Result tabs remain hidden before a search term exists.
 - Other pagination modes can be considered later, but are not part of this phase.
 
 ### PR 5: Product Categories And Content Tabs
@@ -963,3 +963,4 @@ Test coverage by phase:
 - Add responsive styling and CSS variables.
 - Add README documentation.
 - Shopify integration planning after UI Components completion.
+

--- a/packages/web-components/development/search/universal-search/index.html
+++ b/packages/web-components/development/search/universal-search/index.html
@@ -10,7 +10,16 @@
 <body>
     <script type="module" src="index.ts"></script>
     <h1>Universal Search</h1>
-    <p>This page exercises the universal-search modal. It does not perform result searches yet.</p>
+    <p>This page exercises the universal-search modal and the first products tab.</p>
+
+    <ul>
+        <li>Products tab with page size 8.</li>
+        <li>Product facets: brand, immediate parent category, and sales price.</li>
+        <li>Product sorting: relevance, price, name, brand, and popularity.</li>
+        <li>Product rendering through <code>relewise-product-tile</code> with a demo <code>templates.product</code> override.</li>
+        <li>Product images requested from <code>Image</code>, with <code>ImageUrl</code> as fallback.</li>
+        <li>Load more through the existing <code>rw-take</code> URL state.</li>
+    </ul>
 
     <button onclick="document.querySelector('relewise-universal-search').open()">
         Open universal search

--- a/packages/web-components/development/search/universal-search/index.ts
+++ b/packages/web-components/development/search/universal-search/index.ts
@@ -92,10 +92,11 @@ initializeRelewiseUI(
         //     mode: 'Numerical',
         // }),
         universalSearch: {
-            tabs: {
+            entities: {
                 products: {
                     pageSize: 8,
                 },
             },
         },
     });
+

--- a/packages/web-components/development/search/universal-search/index.ts
+++ b/packages/web-components/development/search/universal-search/index.ts
@@ -17,7 +17,85 @@ initializeRelewiseUI(
         clientOptions: {
             serverUrl: import.meta.env.VITE_SERVER_URL,
         },
+        selectedPropertiesSettings: {
+            product: {
+                displayName: true,
+                pricing: true,
+                dataKeys: ['Url', 'Image', 'ImageUrl'],
+            },
+        },
+        templates: {
+            product(product, { html, helpers }) {
+                const url = product.data?.['Url']?.value;
+                const image = product.data?.['Image']?.value ?? product.data?.['ImageUrl']?.value;
+                const content = html`
+                    ${image ? html`
+                        <img
+                            style="display:block;width:100%;aspect-ratio:1/1;object-fit:contain;background:#f7f7f7;"
+                            src=${image}
+                            alt=${product.displayName ?? ''}>
+                    ` : helpers.nothing}
+                    <div style="padding:.75rem;">
+                        <strong style="display:block;margin-bottom:.5rem;">${product.displayName}</strong>
+                        <span>${helpers.formatPrice(product.salesPrice)}</span>
+                    </div>
+                `;
+
+                if (url) {
+                    return html`
+                        <a style="display:block;height:100%;color:inherit;text-decoration:none;border:1px solid #ddd;" href=${url}>
+                            ${content}
+                        </a>
+                    `;
+                }
+
+                return html`
+                    <article style="height:100%;border:1px solid #ddd;">
+                        ${content}
+                    </article>
+                `;
+            },
+        },
     },
-).useSearch({
-    universalSearch: {},
-});
+)
+    .useSearch({
+        facets: {
+            product(builder) {
+                builder
+                    .addFacet((f) => f.addBrandFacet(), { heading: 'Brands' })
+                    .addFacet((f) => f.addCategoryFacet('ImmediateParent'), { heading: 'Categories' })
+                    .addFacet((f) => f.addSalesPriceRangeFacet('Product'), { heading: 'Sales Price' });
+            },
+        },
+        sorting: sorting => sorting
+            .clear()
+            .addRelevance()
+            .addSalesPriceAscending()
+            .addSalesPriceDescending()
+            .addAlphabeticallyAscending()
+            .addAlphabeticallyDescending()
+            .addBrandAscending()
+            .addBrandDescending()
+            .addPopularityAscending()
+            .addPopularityDescending(),
+        // Dataset-specific examples:
+        // filters: {
+        //     product(builder) {
+        //         builder.addProductCategoryIdFilter('ImmediateParent', ['YOUR_CATEGORY_ID']);
+        //     },
+        // },
+        // sorting: sorting => sorting.addProductData({
+        //     label: 'Custom score',
+        //     key: 'YOUR_DATA_KEY',
+        //     selectionStrategy: 'Product',
+        //     order: 'Descending',
+        //     mode: 'Numerical',
+        // }),
+        universalSearch: {
+            tabs: {
+                products: {
+                    pageSize: 8,
+                },
+            },
+        },
+    });

--- a/packages/web-components/src/app.ts
+++ b/packages/web-components/src/app.ts
@@ -51,14 +51,14 @@ export interface RelewiseUISearchOptions {
 }
 
 export interface UniversalSearchOptions {
-    tabs?: UniversalSearchTabsOptions;
+    entities?: UniversalSearchEntitiesOptions;
 }
 
-export interface UniversalSearchTabsOptions {
-    products?: UniversalSearchProductsTabOptions;
+export interface UniversalSearchEntitiesOptions {
+    products?: UniversalSearchProductEntityOptions;
 }
 
-export interface UniversalSearchProductsTabOptions {
+export interface UniversalSearchProductEntityOptions {
     pageSize?: number;
 }
 
@@ -74,7 +74,7 @@ export interface SearchLocalization {
 export interface UniversalSearchLocalization {
     close?: string;
     emptyState?: string;
-    noTabsConfigured?: string;
+    noEntitiesConfigured?: string;
     tabsLabel?: string;
     products?: UniversalSearchProductsLocalization;
 }

--- a/packages/web-components/src/app.ts
+++ b/packages/web-components/src/app.ts
@@ -51,6 +51,15 @@ export interface RelewiseUISearchOptions {
 }
 
 export interface UniversalSearchOptions {
+    tabs?: UniversalSearchTabsOptions;
+}
+
+export interface UniversalSearchTabsOptions {
+    products?: UniversalSearchProductsTabOptions;
+}
+
+export interface UniversalSearchProductsTabOptions {
+    pageSize?: number;
 }
 
 export interface SearchLocalization {

--- a/packages/web-components/src/app.ts
+++ b/packages/web-components/src/app.ts
@@ -74,6 +74,19 @@ export interface SearchLocalization {
 export interface UniversalSearchLocalization {
     close?: string;
     emptyState?: string;
+    noTabsConfigured?: string;
+    tabsLabel?: string;
+    products?: UniversalSearchProductsLocalization;
+}
+
+export interface UniversalSearchProductsLocalization {
+    tab?: string;
+    resultsFor?: string;
+    resultsTitle?: string;
+    result?: string;
+    results?: string;
+    noResults?: string;
+    error?: string;
 }
 
 export interface SearchBarLocalization {

--- a/packages/web-components/src/helpers/urlState.ts
+++ b/packages/web-components/src/helpers/urlState.ts
@@ -26,6 +26,17 @@ export function clearUrlState() {
     window.history.replaceState({}, document.title, currentUrl);
 }
 
+export function clearUrlStateByPrefixes(queryParamNamePrefixes: string[]) {
+    const currentUrl = new URL(window.location.href);
+    const queryParamNames = [...new Set(Array.from(currentUrl.searchParams.keys()))];
+
+    queryParamNames
+        .filter(queryParamName => queryParamNamePrefixes.some(prefix => queryParamName.startsWith(prefix)))
+        .forEach(queryParamName => currentUrl.searchParams.delete(queryParamName));
+
+    window.history.replaceState({}, document.title, currentUrl);
+}
+
 export function updateUrlStateValues(queryParamName: string, values: string[]) {
     const currentUrl = new URL(window.location.href);
     

--- a/packages/web-components/src/search/universal-search.styles.ts
+++ b/packages/web-components/src/search/universal-search.styles.ts
@@ -1,0 +1,154 @@
+import { css } from 'lit';
+import { theme } from '../theme';
+
+export const universalSearchStyles = [theme, css`
+    :host {
+        font-family: var(--font);
+        --relewise-universal-search-color: var(--relewise-color, #212427);
+    }
+
+    .rw-backdrop {
+        position: fixed;
+        inset: 0;
+        z-index: var(--relewise-universal-search-z-index, 1000);
+        background: var(--relewise-universal-search-backdrop-background, rgb(0 0 0 / 0.35));
+        display: flex;
+        justify-content: center;
+        align-items: stretch;
+    }
+
+    .rw-dialog {
+        background: var(--relewise-universal-search-background, white);
+        color: var(--relewise-universal-search-color);
+        --color: var(--relewise-universal-search-color);
+        width: var(--relewise-universal-search-width, 100%);
+        height: var(--relewise-universal-search-height, 100%);
+        display: flex;
+        flex-direction: column;
+    }
+
+    .rw-header {
+        display: flex;
+        gap: var(--relewise-universal-search-header-gap, 1em);
+        align-items: center;
+        padding: var(--relewise-universal-search-header-padding, 1em);
+        border-bottom: 1px solid var(--relewise-universal-search-border-color, #ddd);
+    }
+
+    relewise-search-bar {
+        flex: 1;
+    }
+
+    .rw-close {
+        flex: 0 0 auto;
+        height: var(--relewise-product-search-bar-height, 3em);
+        margin: 0;
+        padding: var(--relewise-universal-search-close-button-padding, 0 0.75em);
+        --relewise-button-icon-padding: 0;
+        --relewise-button-text-color: var(--relewise-universal-search-color);
+    }
+
+    .rw-body {
+        flex: 1;
+        overflow: auto;
+        padding: var(--relewise-universal-search-body-padding, 1em);
+    }
+
+    .rw-empty {
+        margin: 0;
+    }
+
+    .rw-tabs {
+        display: flex;
+        gap: var(--relewise-universal-search-tabs-gap, 0.5em);
+        border-bottom: 1px solid var(--relewise-universal-search-border-color, #ddd);
+        margin-bottom: var(--relewise-universal-search-tabs-margin-bottom, 1em);
+    }
+
+    .rw-tab {
+        appearance: none;
+        background: transparent;
+        border: 0;
+        border-bottom: 2px solid transparent;
+        cursor: pointer;
+        font: inherit;
+        padding: var(--relewise-universal-search-tab-padding, 0.5em 0);
+    }
+
+    .rw-tab[aria-selected="true"] {
+        border-bottom-color: var(--relewise-universal-search-tab-active-border-color, currentColor);
+        font-weight: 600;
+    }
+
+    .rw-tab-count {
+        margin-left: 0.25em;
+        font-size: 0.8em;
+    }
+
+    .rw-results-summary {
+        margin-bottom: var(--relewise-universal-search-results-summary-margin-bottom, 1em);
+    }
+
+    .rw-results-layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        gap: var(--relewise-universal-search-layout-gap, 1em);
+    }
+
+    .rw-results-layout:has(.rw-facets) {
+        grid-template-columns: minmax(10em, var(--relewise-universal-search-facets-width, 14em)) minmax(0, 1fr);
+    }
+
+    .rw-results-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 1em;
+        align-items: center;
+        margin-bottom: var(--relewise-universal-search-results-header-margin-bottom, 1em);
+    }
+
+    .rw-results-title {
+        font-size: var(--relewise-universal-search-results-title-font-size, 1.1em);
+        margin: 0;
+    }
+
+    .rw-results-count {
+        font-size: 0.9em;
+    }
+
+    .rw-product-grid {
+        display: grid;
+        grid-template-columns: repeat(var(--relewise-universal-search-product-columns, 5), minmax(0, 1fr));
+        gap: var(--relewise-universal-search-product-grid-gap, 1em);
+    }
+
+    .rw-loading {
+        display: flex;
+        justify-content: center;
+        padding: var(--relewise-universal-search-loading-padding, 2em 0);
+    }
+
+    .rw-load-more {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5em;
+        margin-top: var(--relewise-universal-search-load-more-margin-top, 1em);
+    }
+
+    @media (max-width: 768px) {
+        .rw-header,
+        .rw-results-header {
+            align-items: stretch;
+            flex-direction: column;
+        }
+
+        .rw-results-layout:has(.rw-facets) {
+            grid-template-columns: minmax(0, 1fr);
+        }
+
+        .rw-product-grid {
+            grid-template-columns: repeat(var(--relewise-universal-search-mobile-product-columns, 2), minmax(0, 1fr));
+        }
+    }
+`];

--- a/packages/web-components/src/search/universal-search.styles.ts
+++ b/packages/web-components/src/search/universal-search.styles.ts
@@ -96,7 +96,7 @@ export const universalSearchStyles = [theme, css`
     }
 
     .rw-results-layout:has(.rw-facets) {
-        grid-template-columns: minmax(10em, var(--relewise-universal-search-facets-width, 14em)) minmax(0, 1fr);
+        grid-template-columns: minmax(10em, var(--relewise-universal-search-facets-width, 18em)) minmax(0, 1fr);
     }
 
     .rw-results-header {

--- a/packages/web-components/src/search/universal-search.ts
+++ b/packages/web-components/src/search/universal-search.ts
@@ -198,7 +198,8 @@ export class UniversalSearch extends RelewiseLitElement {
             this.products = this.products.concat(response.results ?? []);
         } catch (error) {
             if (!abortController.signal.aborted) {
-                this.error = error instanceof Error ? error.message : 'Could not load products.';
+                const productsLocalization = getRelewiseUISearchOptions()?.localization?.universalSearch?.products;
+                this.error = error instanceof Error ? error.message : productsLocalization?.error ?? 'Could not load products.';
             }
         } finally {
             if (!abortController.signal.aborted) {
@@ -253,6 +254,7 @@ export class UniversalSearch extends RelewiseLitElement {
 
     renderDefaultContent() {
         const universalSearchLocalization = getRelewiseUISearchOptions()?.localization?.universalSearch;
+        const productsLocalization = universalSearchLocalization?.products;
 
         if (!this.term) {
             return html`<p class="rw-empty" part="empty-state">${universalSearchLocalization?.emptyState ?? 'Start typing to search.'}</p>`;
@@ -260,13 +262,13 @@ export class UniversalSearch extends RelewiseLitElement {
 
         if (this.productsTabEnabled) {
             return html`
-                <nav class="rw-tabs" part="tabs" aria-label="Search result tabs">
+                <nav class="rw-tabs" part="tabs" aria-label=${universalSearchLocalization?.tabsLabel ?? 'Search result tabs'}>
                     <button
                         class="rw-tab"
                         part="tab"
                         type="button"
                         aria-selected=${this.activeTab === 'products'}>
-                        Products
+                        ${productsLocalization?.tab ?? 'Products'}
                         ${this.searchResult ? html`<span class="rw-tab-count" part="tab-count">${this.searchResult.hits}</span>` : nothing}
                     </button>
                 </nav>
@@ -274,13 +276,15 @@ export class UniversalSearch extends RelewiseLitElement {
             `;
         }
 
-        return html`<p class="rw-empty" part="empty-state">No universal-search tabs configured.</p>`;
+        return html`<p class="rw-empty" part="empty-state">${universalSearchLocalization?.noTabsConfigured ?? 'No universal-search tabs configured.'}</p>`;
     }
 
     renderProductsTab() {
+        const productsLocalization = getRelewiseUISearchOptions()?.localization?.universalSearch?.products;
+
         return html`
             <div class="rw-results-summary" part="results-summary">
-                Search results for <strong>${this.term}</strong>
+                ${productsLocalization?.resultsFor ?? 'Search results for'} <strong>${this.term}</strong>
             </div>
             <div class="rw-results-layout" part="results-layout">
                 ${this.products.length > 0 && this.searchResult?.facets ? html`
@@ -295,9 +299,9 @@ export class UniversalSearch extends RelewiseLitElement {
                 <section class="rw-results" part="results">
                     <header class="rw-results-header" part="results-header">
                         <div>
-                            <h2 class="rw-results-title" part="results-title">Product Results</h2>
+                            <h2 class="rw-results-title" part="results-title">${productsLocalization?.resultsTitle ?? 'Product Results'}</h2>
                             ${this.searchResult ? html`
-                                <span class="rw-results-count" part="results-count">${this.searchResult.hits} products</span>
+                                <span class="rw-results-count" part="results-count">${this.searchResult.hits} ${this.searchResult.hits === 1 ? (productsLocalization?.result ?? 'product') : (productsLocalization?.results ?? 'products')}</span>
                             ` : nothing}
                         </div>
                         ${this.products.length > 0 ? html`
@@ -317,6 +321,7 @@ export class UniversalSearch extends RelewiseLitElement {
 
     renderProductResults() {
         const localization = getRelewiseUISearchOptions()?.localization?.loadMoreButton;
+        const productsLocalization = getRelewiseUISearchOptions()?.localization?.universalSearch?.products;
 
         if (this.error) {
             return html`<p class="rw-empty" part="error-state">${this.error}</p>`;
@@ -327,7 +332,7 @@ export class UniversalSearch extends RelewiseLitElement {
         }
 
         if (this.products.length === 0) {
-            return html`<p class="rw-empty" part="zero-results">No products found.</p>`;
+            return html`<p class="rw-empty" part="zero-results">${productsLocalization?.noResults ?? 'No products found.'}</p>`;
         }
 
         return html`

--- a/packages/web-components/src/search/universal-search.ts
+++ b/packages/web-components/src/search/universal-search.ts
@@ -1,13 +1,20 @@
+import { ProductResult, ProductSearchResponse, User } from '@relewise/client';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { QueryKeys, getRelewiseUISearchOptions, readCurrentUrlState, updateUrlState } from '../helpers';
+import { Events, QueryKeys, getNumberOfProductsToFetch, getRelewiseUISearchOptions, readCurrentUrlState, updateUrlState } from '../helpers';
+import { getRelewiseContextSettings, getRelewiseUIOptions } from '../helpers/relewiseUIOptions';
 import { RelewiseLitElement } from '../relewise-lit-element';
 import { theme } from '../theme';
+import { buildProductSearchRequest } from './productSearchRequestBuilder';
+import { getSearcher } from './searcher';
 
 export class UniversalSearch extends RelewiseLitElement {
 
     @property({ attribute: 'displayed-at-location' })
     displayedAtLocation?: string = undefined;
+
+    @property({ type: String, attribute: 'target' })
+    target: string | null = null;
 
     @property({ type: Boolean, reflect: true, attribute: 'open' })
     isOpen = false;
@@ -15,22 +22,61 @@ export class UniversalSearch extends RelewiseLitElement {
     @state()
     term: string = '';
 
+    @state()
+    activeTab: 'products' | null = null;
+
+    @state()
+    searchResult: ProductSearchResponse | null = null;
+
+    @state()
+    products: ProductResult[] = [];
+
+    @state()
+    page: number = 1;
+
+    @state()
+    loading: boolean = false;
+
+    @state()
+    error: string | null = null;
+
+    @state()
+    facetLabels: string[] = [];
+
+    @state()
+    private user: User | null = null;
+
+    @state()
+    abortController: AbortController = new AbortController();
+
     private debounceTimeoutHandlerId: ReturnType<typeof setTimeout> | null = null;
     private handleWindowKeyDownBound = this.handleWindowKeyDown.bind(this);
+    private handleSearchConfigurationChangedBound = this.handleSearchConfigurationChanged.bind(this);
+    private defaultProductsPageSize = 16;
 
     connectedCallback(): void {
         super.connectedCallback();
         this.term = readCurrentUrlState(QueryKeys.term) ?? '';
+        this.activeTab = this.productsTabEnabled && this.term ? 'products' : null;
         window.addEventListener('keydown', this.handleWindowKeyDownBound);
+        window.addEventListener(Events.applyFacet, this.handleSearchConfigurationChangedBound);
+        window.addEventListener(Events.applySorting, this.handleSearchConfigurationChangedBound);
+
+        if (this.isOpen) {
+            this.searchProducts(true);
+        }
     }
 
     disconnectedCallback(): void {
         window.removeEventListener('keydown', this.handleWindowKeyDownBound);
+        window.removeEventListener(Events.applyFacet, this.handleSearchConfigurationChangedBound);
+        window.removeEventListener(Events.applySorting, this.handleSearchConfigurationChangedBound);
         super.disconnectedCallback();
     }
 
     open(): void {
         this.isOpen = true;
+        this.searchProducts(true);
     }
 
     close(): void {
@@ -45,8 +91,20 @@ export class UniversalSearch extends RelewiseLitElement {
         }
 
         this.debounceTimeoutHandlerId = setTimeout(() => {
-            updateUrlState(QueryKeys.term, this.term);
+            updateUrlState(QueryKeys.term, this.term || null);
+            updateUrlState(QueryKeys.take, null);
+            if (this.isOpen) {
+                this.searchProducts(true);
+            }
         }, getRelewiseUISearchOptions()?.debounceTimeInMs);
+    }
+
+    private get productsTabEnabled(): boolean {
+        return Boolean(getRelewiseUISearchOptions()?.universalSearch?.tabs?.products);
+    }
+
+    private get productsPageSize(): number {
+        return getRelewiseUISearchOptions()?.universalSearch?.tabs?.products?.pageSize ?? this.defaultProductsPageSize;
     }
 
     handleKeyEvent(event: KeyboardEvent): void {
@@ -68,6 +126,84 @@ export class UniversalSearch extends RelewiseLitElement {
     closeWhenClickingOutsideDialog(event: MouseEvent): void {
         if (event.target === event.currentTarget) {
             this.close();
+        }
+    }
+
+    handleSearchConfigurationChanged(): void {
+        if (!this.isOpen || this.activeTab !== 'products') {
+            return;
+        }
+
+        updateUrlState(QueryKeys.take, null);
+        this.searchProducts(true);
+    }
+
+    handleLoadMoreProducts(): void {
+        this.page = this.page + 1;
+        updateUrlState(QueryKeys.take, (this.productsPageSize * this.page).toString());
+        this.searchProducts(false);
+    }
+
+    async searchProducts(shouldClearOldResult: boolean): Promise<void> {
+        this.abortController.abort();
+
+        if (!this.productsTabEnabled || !this.term) {
+            this.activeTab = null;
+            this.products = [];
+            this.searchResult = null;
+            this.error = null;
+            this.loading = false;
+            return;
+        }
+
+        const numberOfProductsToFetch = getNumberOfProductsToFetch();
+        this.activeTab = 'products';
+        this.loading = true;
+        this.error = null;
+
+        if (shouldClearOldResult) {
+            this.page = numberOfProductsToFetch ? numberOfProductsToFetch / this.productsPageSize : 1;
+            this.products = [];
+            this.searchResult = null;
+        }
+
+        const relewiseUIOptions = getRelewiseUIOptions();
+        const searcher = getSearcher(relewiseUIOptions);
+
+        await new Promise(r => setTimeout(r, 0));
+        const settings = await getRelewiseContextSettings(this.displayedAtLocation ?? 'Relewise Universal Search');
+        this.user = settings.user;
+
+        const requestResult = buildProductSearchRequest({
+            term: this.term,
+            settings,
+            page: this.page,
+            pageSize: this.productsPageSize,
+            productsLoaded: this.products.length,
+            productsToFetch: numberOfProductsToFetch,
+            target: this.target,
+        });
+        this.facetLabels = requestResult.facetLabels;
+
+        const abortController = new AbortController();
+        this.abortController = abortController;
+
+        try {
+            const response = await searcher.searchProducts(requestResult.request, { abortSignal: abortController.signal });
+            if (!response) {
+                return;
+            }
+
+            this.searchResult = response;
+            this.products = this.products.concat(response.results ?? []);
+        } catch (error) {
+            if (!abortController.signal.aborted) {
+                this.error = error instanceof Error ? error.message : 'Could not load products.';
+            }
+        } finally {
+            if (!abortController.signal.aborted) {
+                this.loading = false;
+            }
         }
     }
 
@@ -107,11 +243,115 @@ export class UniversalSearch extends RelewiseLitElement {
                     </header>
                     <div class="rw-content" part="content">
                         <slot>
-                            <p class="rw-empty" part="empty-state">${universalSearchLocalization?.emptyState ?? 'Start typing to search.'}</p>
+                            ${this.renderDefaultContent()}
                         </slot>
                     </div>
                 </section>
             </div>
+        `;
+    }
+
+    renderDefaultContent() {
+        const universalSearchLocalization = getRelewiseUISearchOptions()?.localization?.universalSearch;
+
+        if (!this.term) {
+            return html`<p class="rw-empty" part="empty-state">${universalSearchLocalization?.emptyState ?? 'Start typing to search.'}</p>`;
+        }
+
+        if (this.productsTabEnabled) {
+            return html`
+                <nav class="rw-tabs" part="tabs" aria-label="Search result tabs">
+                    <button
+                        class="rw-tab"
+                        part="tab"
+                        type="button"
+                        aria-selected=${this.activeTab === 'products'}>
+                        Products
+                        ${this.searchResult ? html`<span class="rw-tab-count" part="tab-count">${this.searchResult.hits}</span>` : nothing}
+                    </button>
+                </nav>
+                ${this.renderProductsTab()}
+            `;
+        }
+
+        return html`<p class="rw-empty" part="empty-state">No universal-search tabs configured.</p>`;
+    }
+
+    renderProductsTab() {
+        return html`
+            <div class="rw-results-summary" part="results-summary">
+                Search results for <strong>${this.term}</strong>
+            </div>
+            <div class="rw-results-layout" part="results-layout">
+                ${this.products.length > 0 && this.searchResult?.facets ? html`
+                    <relewise-facets
+                        class="rw-facets"
+                        part="facets"
+                        exportparts="container: facet-container, title: facet-title, input: facet-input, label: facet-label, value: facet-value, hits: facet-hits"
+                        .labels=${this.facetLabels}
+                        .facetResult=${this.searchResult.facets}>
+                    </relewise-facets>
+                ` : nothing}
+                <section class="rw-results" part="results">
+                    <header class="rw-results-header" part="results-header">
+                        <div>
+                            <h2 class="rw-results-title" part="results-title">Product Results</h2>
+                            ${this.searchResult ? html`
+                                <span class="rw-results-count" part="results-count">${this.searchResult.hits} products</span>
+                            ` : nothing}
+                        </div>
+                        ${this.products.length > 0 ? html`
+                            <relewise-product-search-sorting
+                                class="rw-sorting"
+                                part="sorting"
+                                .target=${this.target}
+                                exportparts="select: sorting-select, label: sorting-label">
+                            </relewise-product-search-sorting>
+                        ` : nothing}
+                    </header>
+                    ${this.renderProductResults()}
+                </section>
+            </div>
+        `;
+    }
+
+    renderProductResults() {
+        const localization = getRelewiseUISearchOptions()?.localization?.loadMoreButton;
+
+        if (this.error) {
+            return html`<p class="rw-empty" part="error-state">${this.error}</p>`;
+        }
+
+        if (this.loading && this.products.length === 0) {
+            return html`<relewise-loading-spinner></relewise-loading-spinner>`;
+        }
+
+        if (this.products.length === 0) {
+            return html`<p class="rw-empty" part="zero-results">No products found.</p>`;
+        }
+
+        return html`
+            <div class="rw-product-grid" part="product-grid">
+                ${this.products.map(product => html`
+                    <relewise-product-tile
+                        class="rw-product-tile"
+                        part="product-tile"
+                        .product=${product}
+                        .user=${this.user}>
+                    </relewise-product-tile>
+                `)}
+            </div>
+            ${this.loading ? html`<relewise-loading-spinner></relewise-loading-spinner>` : nothing}
+            ${this.searchResult && this.products.length < this.searchResult.hits ? html`
+                <div class="rw-load-more" part="load-more">
+                    <span class="rw-products-shown">
+                        ${localization?.showing ?? 'Showing'} ${this.products.length} ${localization?.outOf ?? 'out of'} ${this.searchResult.hits} ${localization?.products ?? 'products'}
+                    </span>
+                    <relewise-button @click=${this.handleLoadMoreProducts}>
+                        <span>${localization?.loadMore ?? 'Load More'}</span>
+                    </relewise-button>
+                </div>
+            ` : nothing}
         `;
     }
 
@@ -170,6 +410,94 @@ export class UniversalSearch extends RelewiseLitElement {
 
         .rw-empty {
             margin: 0;
+        }
+
+        .rw-tabs {
+            display: flex;
+            gap: var(--relewise-universal-search-tabs-gap, 0.5em);
+            border-bottom: 1px solid var(--relewise-universal-search-border-color, #ddd);
+            margin-bottom: var(--relewise-universal-search-tabs-margin-bottom, 1em);
+        }
+
+        .rw-tab {
+            appearance: none;
+            background: transparent;
+            border: 0;
+            border-bottom: 2px solid transparent;
+            cursor: pointer;
+            font: inherit;
+            padding: var(--relewise-universal-search-tab-padding, 0.5em 0);
+        }
+
+        .rw-tab[aria-selected="true"] {
+            border-bottom-color: var(--relewise-universal-search-tab-active-border-color, currentColor);
+            font-weight: 600;
+        }
+
+        .rw-tab-count {
+            margin-left: 0.25em;
+            font-size: 0.8em;
+        }
+
+        .rw-results-summary {
+            margin-bottom: var(--relewise-universal-search-results-summary-margin-bottom, 1em);
+        }
+
+        .rw-results-layout {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr);
+            gap: var(--relewise-universal-search-layout-gap, 1em);
+        }
+
+        .rw-results-layout:has(.rw-facets) {
+            grid-template-columns: minmax(12em, 1fr) minmax(0, 3fr);
+        }
+
+        .rw-results-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 1em;
+            align-items: center;
+            margin-bottom: var(--relewise-universal-search-results-header-margin-bottom, 1em);
+        }
+
+        .rw-results-title {
+            font-size: var(--relewise-universal-search-results-title-font-size, 1.1em);
+            margin: 0;
+        }
+
+        .rw-results-count {
+            font-size: 0.9em;
+        }
+
+        .rw-product-grid {
+            display: grid;
+            grid-template-columns: repeat(var(--relewise-universal-search-product-columns, 4), minmax(0, 1fr));
+            gap: var(--relewise-universal-search-product-grid-gap, 1em);
+        }
+
+        .rw-load-more {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5em;
+            margin-top: var(--relewise-universal-search-load-more-margin-top, 1em);
+        }
+
+        @media (max-width: 768px) {
+            .rw-header,
+            .rw-results-header {
+                align-items: stretch;
+                flex-direction: column;
+            }
+
+            .rw-results-layout:has(.rw-facets) {
+                grid-template-columns: minmax(0, 1fr);
+            }
+
+            .rw-product-grid {
+                grid-template-columns: repeat(var(--relewise-universal-search-mobile-product-columns, 2), minmax(0, 1fr));
+            }
         }
     `];
 }

--- a/packages/web-components/src/search/universal-search.ts
+++ b/packages/web-components/src/search/universal-search.ts
@@ -1,7 +1,7 @@
 import { ProductResult, ProductSearchResponse, User } from '@relewise/client';
 import { css, html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { Events, QueryKeys, getNumberOfProductsToFetch, getRelewiseUISearchOptions, readCurrentUrlState, updateUrlState } from '../helpers';
+import { Events, QueryKeys, clearUrlStateByPrefixes, getNumberOfProductsToFetch, getRelewiseUISearchOptions, readCurrentUrlState, updateUrlState } from '../helpers';
 import { getRelewiseContextSettings, getRelewiseUIOptions } from '../helpers/relewiseUIOptions';
 import { RelewiseLitElement } from '../relewise-lit-element';
 import { theme } from '../theme';
@@ -105,6 +105,7 @@ export class UniversalSearch extends RelewiseLitElement {
         this.debounceTimeoutHandlerId = setTimeout(() => {
             updateUrlState(QueryKeys.term, this.term || null);
             updateUrlState(QueryKeys.take, null);
+            clearUrlStateByPrefixes([QueryKeys.facet, QueryKeys.facetUpperbound, QueryKeys.facetLowerbound]);
             if (this.isOpen) {
                 this.searchProducts(true);
             }
@@ -311,7 +312,7 @@ export class UniversalSearch extends RelewiseLitElement {
                 <section class="rw-results" part="results">
                     <header class="rw-results-header" part="results-header">
                         <div>
-                            <h2 class="rw-results-title" part="results-title">${productsLocalization?.resultsTitle ?? 'Product Results'}</h2>
+                            <h2 class="rw-results-title" part="results-title">${productsLocalization?.resultsTitle ?? 'Products'}</h2>
                             ${this.searchResult ? html`
                                 <span class="rw-results-count" part="results-count">${this.searchResult.hits} ${this.searchResult.hits === 1 ? (productsLocalization?.result ?? 'product') : (productsLocalization?.results ?? 'products')}</span>
                             ` : nothing}
@@ -340,7 +341,11 @@ export class UniversalSearch extends RelewiseLitElement {
         }
 
         if (this.loading && this.products.length === 0) {
-            return html`<relewise-loading-spinner></relewise-loading-spinner>`;
+            return html`
+                <div class="rw-loading" part="loading-state">
+                    <relewise-loading-spinner></relewise-loading-spinner>
+                </div>
+            `;
         }
 
         if (!this.searchResult) {
@@ -362,7 +367,11 @@ export class UniversalSearch extends RelewiseLitElement {
                     </relewise-product-tile>
                 `)}
             </div>
-            ${this.loading ? html`<relewise-loading-spinner></relewise-loading-spinner>` : nothing}
+            ${this.loading ? html`
+                <div class="rw-loading" part="loading-state">
+                    <relewise-loading-spinner></relewise-loading-spinner>
+                </div>
+            ` : nothing}
             ${this.searchResult && this.products.length < this.searchResult.hits ? html`
                 <div class="rw-load-more" part="load-more">
                     <span class="rw-products-shown">
@@ -471,7 +480,7 @@ export class UniversalSearch extends RelewiseLitElement {
         }
 
         .rw-results-layout:has(.rw-facets) {
-            grid-template-columns: minmax(12em, 1fr) minmax(0, 3fr);
+            grid-template-columns: minmax(10em, var(--relewise-universal-search-facets-width, 14em)) minmax(0, 1fr);
         }
 
         .rw-results-header {
@@ -493,8 +502,14 @@ export class UniversalSearch extends RelewiseLitElement {
 
         .rw-product-grid {
             display: grid;
-            grid-template-columns: repeat(var(--relewise-universal-search-product-columns, 4), minmax(0, 1fr));
+            grid-template-columns: repeat(var(--relewise-universal-search-product-columns, 5), minmax(0, 1fr));
             gap: var(--relewise-universal-search-product-grid-gap, 1em);
+        }
+
+        .rw-loading {
+            display: flex;
+            justify-content: center;
+            padding: var(--relewise-universal-search-loading-padding, 2em 0);
         }
 
         .rw-load-more {

--- a/packages/web-components/src/search/universal-search.ts
+++ b/packages/web-components/src/search/universal-search.ts
@@ -80,11 +80,23 @@ export class UniversalSearch extends RelewiseLitElement {
     }
 
     close(): void {
+        this.abortController.abort();
+        this.loading = false;
         this.isOpen = false;
     }
 
     setSearchTerm(term: string): void {
+        if (this.term === term) {
+            return;
+        }
+
         this.term = term;
+        this.abortController.abort();
+        this.activeTab = this.productsTabEnabled && this.term ? 'products' : null;
+        this.products = [];
+        this.searchResult = null;
+        this.error = null;
+        this.loading = Boolean(this.isOpen && this.term && this.productsTabEnabled);
 
         if (this.debounceTimeoutHandlerId) {
             clearTimeout(this.debounceTimeoutHandlerId);
@@ -329,6 +341,10 @@ export class UniversalSearch extends RelewiseLitElement {
 
         if (this.loading && this.products.length === 0) {
             return html`<relewise-loading-spinner></relewise-loading-spinner>`;
+        }
+
+        if (!this.searchResult) {
+            return nothing;
         }
 
         if (this.products.length === 0) {

--- a/packages/web-components/src/search/universal-search.ts
+++ b/packages/web-components/src/search/universal-search.ts
@@ -52,7 +52,7 @@ export class UniversalSearch extends RelewiseLitElement {
     private debounceTimeoutHandlerId: ReturnType<typeof setTimeout> | null = null;
     private handleWindowKeyDownBound = this.handleWindowKeyDown.bind(this);
     private handleSearchConfigurationChangedBound = this.handleSearchConfigurationChanged.bind(this);
-    private defaultProductsPageSize = 16;
+    private defaultProductsPageSize = 15;
 
     connectedCallback(): void {
         super.connectedCallback();

--- a/packages/web-components/src/search/universal-search.ts
+++ b/packages/web-components/src/search/universal-search.ts
@@ -1,12 +1,12 @@
 import { ProductResult, ProductSearchResponse, User } from '@relewise/client';
-import { css, html, nothing } from 'lit';
+import { html, nothing } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { Events, QueryKeys, clearUrlStateByPrefixes, getNumberOfProductsToFetch, getRelewiseUISearchOptions, readCurrentUrlState, updateUrlState } from '../helpers';
 import { getRelewiseContextSettings, getRelewiseUIOptions } from '../helpers/relewiseUIOptions';
 import { RelewiseLitElement } from '../relewise-lit-element';
-import { theme } from '../theme';
 import { buildProductSearchRequest } from './productSearchRequestBuilder';
 import { getSearcher } from './searcher';
+import { universalSearchStyles } from './universal-search.styles';
 
 export class UniversalSearch extends RelewiseLitElement {
 
@@ -113,11 +113,11 @@ export class UniversalSearch extends RelewiseLitElement {
     }
 
     private get productsTabEnabled(): boolean {
-        return Boolean(getRelewiseUISearchOptions()?.universalSearch?.tabs?.products);
+        return Boolean(getRelewiseUISearchOptions()?.universalSearch?.entities?.products);
     }
 
     private get productsPageSize(): number {
-        return getRelewiseUISearchOptions()?.universalSearch?.tabs?.products?.pageSize ?? this.defaultProductsPageSize;
+        return getRelewiseUISearchOptions()?.universalSearch?.entities?.products?.pageSize ?? this.defaultProductsPageSize;
     }
 
     handleKeyEvent(event: KeyboardEvent): void {
@@ -275,6 +275,7 @@ export class UniversalSearch extends RelewiseLitElement {
 
         if (this.productsTabEnabled) {
             return html`
+                ${this.renderResultsSummary()}
                 <nav class="rw-tabs" part="tabs" aria-label=${universalSearchLocalization?.tabsLabel ?? 'Search result tabs'}>
                     <button
                         class="rw-tab"
@@ -289,16 +290,23 @@ export class UniversalSearch extends RelewiseLitElement {
             `;
         }
 
-        return html`<p class="rw-empty" part="empty-state">${universalSearchLocalization?.noTabsConfigured ?? 'No universal-search tabs configured.'}</p>`;
+        return html`<p class="rw-empty" part="empty-state">${universalSearchLocalization?.noEntitiesConfigured ?? 'No universal-search entities configured.'}</p>`;
     }
 
-    renderProductsTab() {
+    renderResultsSummary() {
         const productsLocalization = getRelewiseUISearchOptions()?.localization?.universalSearch?.products;
 
         return html`
             <div class="rw-results-summary" part="results-summary">
                 ${productsLocalization?.resultsFor ?? 'Search results for'} <strong>${this.term}</strong>
             </div>
+        `;
+    }
+
+    renderProductsTab() {
+        const productsLocalization = getRelewiseUISearchOptions()?.localization?.universalSearch?.products;
+
+        return html`
             <div class="rw-results-layout" part="results-layout">
                 ${this.products.length > 0 && this.searchResult?.facets ? html`
                     <relewise-facets
@@ -385,157 +393,7 @@ export class UniversalSearch extends RelewiseLitElement {
         `;
     }
 
-    static styles = [theme, css`
-        :host {
-            font-family: var(--font);
-            --relewise-universal-search-color: var(--relewise-color, #212427);
-        }
-
-        .rw-backdrop {
-            position: fixed;
-            inset: 0;
-            z-index: var(--relewise-universal-search-z-index, 1000);
-            background: var(--relewise-universal-search-backdrop-background, rgb(0 0 0 / 0.35));
-            display: flex;
-            justify-content: center;
-            align-items: stretch;
-        }
-
-        .rw-dialog {
-            background: var(--relewise-universal-search-background, white);
-            color: var(--relewise-universal-search-color);
-            --color: var(--relewise-universal-search-color);
-            width: var(--relewise-universal-search-width, 100%);
-            height: var(--relewise-universal-search-height, 100%);
-            display: flex;
-            flex-direction: column;
-        }
-
-        .rw-header {
-            display: flex;
-            gap: var(--relewise-universal-search-header-gap, 1em);
-            align-items: center;
-            padding: var(--relewise-universal-search-header-padding, 1em);
-            border-bottom: 1px solid var(--relewise-universal-search-border-color, #ddd);
-        }
-
-        relewise-search-bar {
-            flex: 1;
-        }
-
-        .rw-close {
-            flex: 0 0 auto;
-            height: var(--relewise-product-search-bar-height, 3em);
-            margin: 0;
-            padding: var(--relewise-universal-search-close-button-padding, 0 0.75em);
-            --relewise-button-icon-padding: 0;
-            --relewise-button-text-color: var(--relewise-universal-search-color);
-        }
-
-        .rw-body {
-            flex: 1;
-            overflow: auto;
-            padding: var(--relewise-universal-search-body-padding, 1em);
-        }
-
-        .rw-empty {
-            margin: 0;
-        }
-
-        .rw-tabs {
-            display: flex;
-            gap: var(--relewise-universal-search-tabs-gap, 0.5em);
-            border-bottom: 1px solid var(--relewise-universal-search-border-color, #ddd);
-            margin-bottom: var(--relewise-universal-search-tabs-margin-bottom, 1em);
-        }
-
-        .rw-tab {
-            appearance: none;
-            background: transparent;
-            border: 0;
-            border-bottom: 2px solid transparent;
-            cursor: pointer;
-            font: inherit;
-            padding: var(--relewise-universal-search-tab-padding, 0.5em 0);
-        }
-
-        .rw-tab[aria-selected="true"] {
-            border-bottom-color: var(--relewise-universal-search-tab-active-border-color, currentColor);
-            font-weight: 600;
-        }
-
-        .rw-tab-count {
-            margin-left: 0.25em;
-            font-size: 0.8em;
-        }
-
-        .rw-results-summary {
-            margin-bottom: var(--relewise-universal-search-results-summary-margin-bottom, 1em);
-        }
-
-        .rw-results-layout {
-            display: grid;
-            grid-template-columns: minmax(0, 1fr);
-            gap: var(--relewise-universal-search-layout-gap, 1em);
-        }
-
-        .rw-results-layout:has(.rw-facets) {
-            grid-template-columns: minmax(10em, var(--relewise-universal-search-facets-width, 14em)) minmax(0, 1fr);
-        }
-
-        .rw-results-header {
-            display: flex;
-            justify-content: space-between;
-            gap: 1em;
-            align-items: center;
-            margin-bottom: var(--relewise-universal-search-results-header-margin-bottom, 1em);
-        }
-
-        .rw-results-title {
-            font-size: var(--relewise-universal-search-results-title-font-size, 1.1em);
-            margin: 0;
-        }
-
-        .rw-results-count {
-            font-size: 0.9em;
-        }
-
-        .rw-product-grid {
-            display: grid;
-            grid-template-columns: repeat(var(--relewise-universal-search-product-columns, 5), minmax(0, 1fr));
-            gap: var(--relewise-universal-search-product-grid-gap, 1em);
-        }
-
-        .rw-loading {
-            display: flex;
-            justify-content: center;
-            padding: var(--relewise-universal-search-loading-padding, 2em 0);
-        }
-
-        .rw-load-more {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 0.5em;
-            margin-top: var(--relewise-universal-search-load-more-margin-top, 1em);
-        }
-
-        @media (max-width: 768px) {
-            .rw-header,
-            .rw-results-header {
-                align-items: stretch;
-                flex-direction: column;
-            }
-
-            .rw-results-layout:has(.rw-facets) {
-                grid-template-columns: minmax(0, 1fr);
-            }
-
-            .rw-product-grid {
-                grid-template-columns: repeat(var(--relewise-universal-search-mobile-product-columns, 2), minmax(0, 1fr));
-            }
-        }
-    `];
+    static styles = universalSearchStyles;
 }
 
 declare global {

--- a/packages/web-components/src/search/universal-search.ts
+++ b/packages/web-components/src/search/universal-search.ts
@@ -242,9 +242,9 @@ export class UniversalSearch extends RelewiseLitElement {
                             @click=${this.close}>
                         </relewise-button>
                     </header>
-                    <div class="rw-content" part="content">
+                    <div class="rw-body" part="body">
                         <slot>
-                            ${this.renderDefaultContent()}
+                            ${this.renderDefaultView()}
                         </slot>
                     </div>
                 </section>
@@ -252,7 +252,7 @@ export class UniversalSearch extends RelewiseLitElement {
         `;
     }
 
-    renderDefaultContent() {
+    renderDefaultView() {
         const universalSearchLocalization = getRelewiseUISearchOptions()?.localization?.universalSearch;
         const productsLocalization = universalSearchLocalization?.products;
 
@@ -407,10 +407,10 @@ export class UniversalSearch extends RelewiseLitElement {
             --relewise-button-text-color: var(--relewise-universal-search-color);
         }
 
-        .rw-content {
+        .rw-body {
             flex: 1;
             overflow: auto;
-            padding: var(--relewise-universal-search-content-padding, 1em);
+            padding: var(--relewise-universal-search-body-padding, 1em);
         }
 
         .rw-empty {

--- a/packages/web-components/tests/universalSearch.test.ts
+++ b/packages/web-components/tests/universalSearch.test.ts
@@ -169,6 +169,60 @@ suite('relewise-universal-search', () => {
         assert.equal(el.shadowRoot!.querySelectorAll('relewise-product-tile').length, 1);
     });
 
+    test('does not render zero results before product search responds', async () => {
+        Searcher.prototype.searchProducts = async function() {
+            return {
+                hits: 0,
+                results: [],
+                facets: null,
+            } as any;
+        };
+
+        initializeRelewiseUI(mockRelewiseOptions());
+        useSearch({ debounceTimeInMs: 50, universalSearch: { tabs: { products: {} } } });
+
+        const el = await fixture(html`
+            <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
+        `) as UniversalSearch;
+
+        el.setSearchTerm('shoe');
+        await el.updateComplete;
+
+        assert.isNull(el.shadowRoot!.querySelector('[part="zero-results"]'));
+        assert.isNotNull(el.shadowRoot!.querySelector('relewise-loading-spinner'));
+
+        await waitUntil(() => el.shadowRoot!.querySelector('[part="zero-results"]') !== null, 'zero-results was not rendered after search response');
+    });
+
+    test('clears previous products when the search term changes', async () => {
+        Searcher.prototype.searchProducts = async function(request) {
+            return {
+                hits: 1,
+                results: [product(request.term ?? 'missing')],
+                facets: null,
+            } as any;
+        };
+
+        initializeRelewiseUI(mockRelewiseOptions());
+        useSearch({ debounceTimeInMs: 50, universalSearch: { tabs: { products: {} } } });
+
+        const el = await fixture(html`
+            <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
+        `) as UniversalSearch;
+
+        el.setSearchTerm('shoe');
+        await waitUntil(() => el.products.length === 1, 'initial products were not rendered');
+
+        el.setSearchTerm('boot');
+        await el.updateComplete;
+
+        assert.equal(el.products.length, 0);
+        assert.equal(el.shadowRoot!.querySelectorAll('relewise-product-tile').length, 0);
+
+        await waitUntil(() => el.products.length === 1, 'new products were not rendered');
+        assert.equal(el.products[0].productId, 'boot');
+    });
+
     test('uses products tab localization', async () => {
         Searcher.prototype.searchProducts = async function() {
             return {

--- a/packages/web-components/tests/universalSearch.test.ts
+++ b/packages/web-components/tests/universalSearch.test.ts
@@ -1,9 +1,30 @@
 import { assert, fixture, fixtureCleanup, html, waitUntil } from '@open-wc/testing';
-import { clearUrlState, UniversalSearch, QueryKeys, readCurrentUrlState, updateUrlState, useSearch } from '../src';
+import { ProductResult, Searcher } from '@relewise/client';
+import { clearUrlState, UniversalSearch, initializeRelewiseUI, QueryKeys, readCurrentUrlState, updateUrlState, useSearch } from '../src';
+import { mockRelewiseOptions } from './util/mockRelewiseUIOptions';
+
+function product(productId: string): ProductResult {
+    return {
+        productId,
+        rank: 1,
+        displayName: `Product ${productId}`,
+        salesPrice: 10,
+        data: {
+            Url: {
+                type: 'String',
+                isCollection: false,
+                value: `/products/${productId}`,
+            },
+        },
+    } as ProductResult;
+}
 
 suite('relewise-universal-search', () => {
+    const originalSearchProducts = Searcher.prototype.searchProducts;
+
     setup(() => {
         clearUrlState();
+        Searcher.prototype.searchProducts = originalSearchProducts;
         useSearch({ debounceTimeInMs: 0, universalSearch: {} });
     });
 
@@ -11,6 +32,8 @@ suite('relewise-universal-search', () => {
         clearUrlState();
         fixtureCleanup();
         window.relewiseUISearchOptions = undefined!;
+        window.relewiseUIOptions = undefined!;
+        Searcher.prototype.searchProducts = originalSearchProducts;
     });
 
     test('is registered through useSearch', () => {
@@ -100,5 +123,108 @@ suite('relewise-universal-search', () => {
         el.setSearchTerm('shoe');
 
         await waitUntil(() => readCurrentUrlState(QueryKeys.term) === 'shoe', 'term was not written to URL state');
+    });
+
+    test('does not render tabs without a search term', async () => {
+        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: {} } } });
+
+        const el = await fixture(html`
+            <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
+        `) as UniversalSearch;
+
+        assert.isNull(el.shadowRoot!.querySelector('[part="tabs"]'));
+        assert.include(el.shadowRoot!.textContent ?? '', 'Start typing to search.');
+    });
+
+    test('searches and renders products when products tab is configured', async () => {
+        let capturedTerm: string | null = null;
+
+        Searcher.prototype.searchProducts = async function(request) {
+            capturedTerm = request.term ?? null;
+
+            return {
+                hits: 1,
+                results: [product('1')],
+                facets: null,
+            } as any;
+        };
+
+        initializeRelewiseUI(mockRelewiseOptions());
+        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: { pageSize: 2 } } } });
+
+        const el = await fixture(html`
+            <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
+        `) as UniversalSearch;
+
+        el.setSearchTerm('shoe');
+
+        await waitUntil(() => el.products.length === 1, 'products were not rendered');
+
+        assert.equal(capturedTerm, 'shoe');
+        assert.isNotNull(el.shadowRoot!.querySelector('[part="tabs"]'));
+        assert.equal(el.shadowRoot!.querySelectorAll('relewise-product-tile').length, 1);
+    });
+
+    test('loads more products using existing take URL state', async () => {
+        let searchCount = 0;
+
+        Searcher.prototype.searchProducts = async function() {
+            searchCount++;
+
+            return {
+                hits: 3,
+                results: searchCount === 1 ? [product('1'), product('2')] : [product('3')],
+                facets: null,
+            } as any;
+        };
+
+        initializeRelewiseUI(mockRelewiseOptions());
+        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: { pageSize: 2 } } } });
+
+        const el = await fixture(html`
+            <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
+        `) as UniversalSearch;
+
+        el.setSearchTerm('shoe');
+        await waitUntil(() => el.products.length === 2, 'initial products were not rendered');
+
+        el.handleLoadMoreProducts();
+        await waitUntil(() => el.products.length === 3, 'more products were not appended');
+
+        assert.equal(readCurrentUrlState(QueryKeys.take), '4');
+        assert.equal(el.shadowRoot!.querySelectorAll('relewise-product-tile').length, 3);
+    });
+
+    test('continues load more from an existing take URL state', async () => {
+        let searchCount = 0;
+
+        Searcher.prototype.searchProducts = async function() {
+            searchCount++;
+
+            return {
+                hits: 6,
+                results: searchCount === 1
+                    ? [product('1'), product('2'), product('3'), product('4')]
+                    : [product('5'), product('6')],
+                facets: null,
+            } as any;
+        };
+
+        updateUrlState(QueryKeys.term, 'shoe');
+        updateUrlState(QueryKeys.take, '4');
+
+        initializeRelewiseUI(mockRelewiseOptions());
+        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: { pageSize: 2 } } } });
+
+        const el = await fixture(html`
+            <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
+        `) as UniversalSearch;
+
+        await waitUntil(() => el.products.length === 4, 'initial URL take was not loaded');
+
+        el.handleLoadMoreProducts();
+        await waitUntil(() => el.products.length === 6, 'more products were not appended after URL take');
+
+        assert.equal(readCurrentUrlState(QueryKeys.take), '6');
     });
 });

--- a/packages/web-components/tests/universalSearch.test.ts
+++ b/packages/web-components/tests/universalSearch.test.ts
@@ -1,6 +1,6 @@
 import { assert, fixture, fixtureCleanup, html, waitUntil } from '@open-wc/testing';
 import { ProductResult, Searcher } from '@relewise/client';
-import { clearUrlState, UniversalSearch, initializeRelewiseUI, QueryKeys, readCurrentUrlState, updateUrlState, useSearch } from '../src';
+import { clearUrlState, UniversalSearch, initializeRelewiseUI, QueryKeys, readCurrentUrlState, updateUrlState, updateUrlStateValues, useSearch } from '../src';
 import { mockRelewiseOptions } from './util/mockRelewiseUIOptions';
 
 function product(productId: string): ProductResult {
@@ -221,6 +221,37 @@ suite('relewise-universal-search', () => {
 
         await waitUntil(() => el.products.length === 1, 'new products were not rendered');
         assert.equal(el.products[0].productId, 'boot');
+    });
+
+    test('clears facet URL state when the search term changes', async () => {
+        Searcher.prototype.searchProducts = async function() {
+            return {
+                hits: 0,
+                results: [],
+                facets: null,
+            } as any;
+        };
+
+        updateUrlStateValues(QueryKeys.facet + 'Brand', ['Adidas', 'Nike']);
+        updateUrlState(QueryKeys.facetLowerbound + 'SalesPrice', '50');
+        updateUrlState(QueryKeys.facetUpperbound + 'SalesPrice', '100');
+        updateUrlState(QueryKeys.sortBy, 'price');
+
+        initializeRelewiseUI(mockRelewiseOptions());
+        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: {} } } });
+
+        const el = await fixture(html`
+            <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
+        `) as UniversalSearch;
+
+        el.setSearchTerm('boot');
+
+        await waitUntil(() => readCurrentUrlState(QueryKeys.term) === 'boot', 'term was not written to URL state');
+
+        assert.deepEqual(new URL(window.location.href).searchParams.getAll(QueryKeys.facet + 'Brand'), []);
+        assert.isNull(readCurrentUrlState(QueryKeys.facetLowerbound + 'SalesPrice'));
+        assert.isNull(readCurrentUrlState(QueryKeys.facetUpperbound + 'SalesPrice'));
+        assert.equal(readCurrentUrlState(QueryKeys.sortBy), 'price');
     });
 
     test('uses products tab localization', async () => {

--- a/packages/web-components/tests/universalSearch.test.ts
+++ b/packages/web-components/tests/universalSearch.test.ts
@@ -89,7 +89,7 @@ suite('relewise-universal-search', () => {
                 universalSearch: {
                     close: 'Luk',
                     emptyState: 'Begynd at søge.',
-                    noTabsConfigured: 'Ingen faner konfigureret.',
+                    noEntitiesConfigured: 'Ingen faner konfigureret.',
                 },
             },
         });
@@ -130,7 +130,7 @@ suite('relewise-universal-search', () => {
     });
 
     test('does not render tabs without a search term', async () => {
-        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: {} } } });
+        useSearch({ debounceTimeInMs: 0, universalSearch: { entities: { products: {} } } });
 
         const el = await fixture(html`
             <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
@@ -154,7 +154,7 @@ suite('relewise-universal-search', () => {
         };
 
         initializeRelewiseUI(mockRelewiseOptions());
-        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: { pageSize: 2 } } } });
+        useSearch({ debounceTimeInMs: 0, universalSearch: { entities: { products: { pageSize: 2 } } } });
 
         const el = await fixture(html`
             <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
@@ -179,7 +179,7 @@ suite('relewise-universal-search', () => {
         };
 
         initializeRelewiseUI(mockRelewiseOptions());
-        useSearch({ debounceTimeInMs: 50, universalSearch: { tabs: { products: {} } } });
+        useSearch({ debounceTimeInMs: 50, universalSearch: { entities: { products: {} } } });
 
         const el = await fixture(html`
             <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
@@ -204,7 +204,7 @@ suite('relewise-universal-search', () => {
         };
 
         initializeRelewiseUI(mockRelewiseOptions());
-        useSearch({ debounceTimeInMs: 50, universalSearch: { tabs: { products: {} } } });
+        useSearch({ debounceTimeInMs: 50, universalSearch: { entities: { products: {} } } });
 
         const el = await fixture(html`
             <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
@@ -238,7 +238,7 @@ suite('relewise-universal-search', () => {
         updateUrlState(QueryKeys.sortBy, 'price');
 
         initializeRelewiseUI(mockRelewiseOptions());
-        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: {} } } });
+        useSearch({ debounceTimeInMs: 0, universalSearch: { entities: { products: {} } } });
 
         const el = await fixture(html`
             <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
@@ -266,7 +266,7 @@ suite('relewise-universal-search', () => {
         initializeRelewiseUI(mockRelewiseOptions());
         useSearch({
             debounceTimeInMs: 0,
-            universalSearch: { tabs: { products: { pageSize: 2 } } },
+            universalSearch: { entities: { products: { pageSize: 2 } } },
             localization: {
                 universalSearch: {
                     tabsLabel: 'Søgeresultatfaner',
@@ -311,7 +311,7 @@ suite('relewise-universal-search', () => {
         };
 
         initializeRelewiseUI(mockRelewiseOptions());
-        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: { pageSize: 2 } } } });
+        useSearch({ debounceTimeInMs: 0, universalSearch: { entities: { products: { pageSize: 2 } } } });
 
         const el = await fixture(html`
             <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
@@ -346,7 +346,7 @@ suite('relewise-universal-search', () => {
         updateUrlState(QueryKeys.take, '4');
 
         initializeRelewiseUI(mockRelewiseOptions());
-        useSearch({ debounceTimeInMs: 0, universalSearch: { tabs: { products: { pageSize: 2 } } } });
+        useSearch({ debounceTimeInMs: 0, universalSearch: { entities: { products: { pageSize: 2 } } } });
 
         const el = await fixture(html`
             <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
@@ -360,3 +360,4 @@ suite('relewise-universal-search', () => {
         assert.equal(readCurrentUrlState(QueryKeys.take), '6');
     });
 });
+

--- a/packages/web-components/tests/universalSearch.test.ts
+++ b/packages/web-components/tests/universalSearch.test.ts
@@ -89,6 +89,7 @@ suite('relewise-universal-search', () => {
                 universalSearch: {
                     close: 'Luk',
                     emptyState: 'Begynd at søge.',
+                    noTabsConfigured: 'Ingen faner konfigureret.',
                 },
             },
         });
@@ -102,6 +103,9 @@ suite('relewise-universal-search', () => {
 
         assert.equal(closeButton?.getAttribute('button-text'), 'Luk');
         assert.equal(emptyState?.textContent?.trim(), 'Begynd at søge.');
+
+        el.setSearchTerm('sko');
+        await waitUntil(() => el.shadowRoot!.textContent?.includes('Ingen faner konfigureret.'), 'no tabs text was not localized');
     });
 
     test('closes on Escape', async () => {
@@ -163,6 +167,49 @@ suite('relewise-universal-search', () => {
         assert.equal(capturedTerm, 'shoe');
         assert.isNotNull(el.shadowRoot!.querySelector('[part="tabs"]'));
         assert.equal(el.shadowRoot!.querySelectorAll('relewise-product-tile').length, 1);
+    });
+
+    test('uses products tab localization', async () => {
+        Searcher.prototype.searchProducts = async function() {
+            return {
+                hits: 0,
+                results: [],
+                facets: null,
+            } as any;
+        };
+
+        initializeRelewiseUI(mockRelewiseOptions());
+        useSearch({
+            debounceTimeInMs: 0,
+            universalSearch: { tabs: { products: { pageSize: 2 } } },
+            localization: {
+                universalSearch: {
+                    tabsLabel: 'Søgeresultatfaner',
+                    products: {
+                        tab: 'Varer',
+                        resultsFor: 'Søgeresultater for',
+                        resultsTitle: 'Vareresultater',
+                        result: 'vare',
+                        results: 'varer',
+                        noResults: 'Ingen varer fundet.',
+                    },
+                },
+            },
+        });
+
+        const el = await fixture(html`
+            <relewise-universal-search displayed-at-location="Universal Search" open></relewise-universal-search>
+        `) as UniversalSearch;
+
+        el.setSearchTerm('sko');
+        await waitUntil(() => el.shadowRoot!.querySelector('[part="zero-results"]') !== null, 'zero-results was not rendered');
+
+        assert.equal(el.shadowRoot!.querySelector('[part="tabs"]')?.getAttribute('aria-label'), 'Søgeresultatfaner');
+        assert.include(el.shadowRoot!.querySelector('[part="tab"]')?.textContent ?? '', 'Varer');
+        assert.include(el.shadowRoot!.querySelector('[part="results-summary"]')?.textContent ?? '', 'Søgeresultater for');
+        assert.equal(el.shadowRoot!.querySelector('[part="results-title"]')?.textContent?.trim(), 'Vareresultater');
+        assert.equal(el.shadowRoot!.querySelector('[part="results-count"]')?.textContent?.trim(), '0 varer');
+        assert.equal(el.shadowRoot!.querySelector('[part="zero-results"]')?.textContent?.trim(), 'Ingen varer fundet.');
     });
 
     test('loads more products using existing take URL state', async () => {


### PR DESCRIPTION
https://trello.com/c/L7kqIawz/20852-full-page-search-products-tab

## Summary

Adds the products tab to Universal Search.

This builds on the Universal Search shell and wires product search into the existing UI Components search architecture.

## Changes

- Adds `universalSearch.tabs.products` configuration.
- Adds product-tab rendering inside `relewise-universal-search`.
- Reuses the shared product search request builder.
- Reuses existing product filters, facets, sorting, relevance modifiers, selected properties, and target overrides.
- Renders products with `relewise-product-tile`, so existing `templates.product` overrides continue to apply.
- Adds load-more support using the existing `rw-take` URL state.
- Adds product-tab localization under `localization.universalSearch.products`.
- Updates the Universal Search dev page with product facets, sorting, templates, images, and load more.
- Updates README and the Universal Search implementation plan.
- Adds tests for product search behavior, localization, loading/zero-result states, URL state, and load more.

## Validation

- `npm run build` passed
- `npm run build:types` passed
- `npm run test -- tests/universalSearch.test.ts`
  - Chromium: 14 passed
  - WebKit: 14 passed
  - Firefox: local browser startup timed out before running tests