### PR TITLE
Fix iOS product search overlay scrolling

### DIFF
--- a/packages/web-components/src/search/components/product-search-overlay-results.ts
+++ b/packages/web-components/src/search/components/product-search-overlay-results.ts
@@ -29,6 +29,9 @@ export class ProductSearchOverlayResults extends RelewiseLitElement {
     @property()
     setResultOverlayHovered = (hovered: boolean) => { };
 
+    @property()
+    closeSearchKeyboard = () => { };
+
     @property({ type: Object })
     user: User | null = null;
 
@@ -56,6 +59,9 @@ export class ProductSearchOverlayResults extends RelewiseLitElement {
 
         return html`
             <div class="rw-result-container rw-border" part="overlay"
+                @pointerdown=${() => this.setResultOverlayHovered(true)}
+                @touchstart=${() => this.setResultOverlayHovered(true)}
+                @touchmove=${() => this.closeSearchKeyboard()}
                 @mouseover=${() => this.setResultOverlayHovered(true)}
                 @mouseleave=${() => this.setResultOverlayHovered(false)}>
                 ${(!this.results ||

--- a/packages/web-components/src/search/components/search-bar.ts
+++ b/packages/web-components/src/search/components/search-bar.ts
@@ -34,14 +34,14 @@ export class SearchBar extends RelewiseLitElement {
     }
 
     focusSearchInput() {
-        const searchInput = this.shadowRoot?.getElementById('search-input');
+        const searchInput = this.renderRoot.querySelector<HTMLInputElement>('#search-input');
         if (searchInput) {
             searchInput.focus();
         }
     }
 
     blurSearchInput() {
-        const searchInput = this.shadowRoot?.getElementById('search-input');
+        const searchInput = this.renderRoot.querySelector<HTMLInputElement>('#search-input');
         if (searchInput) {
             searchInput.blur();
         }

--- a/packages/web-components/src/search/components/search-bar.ts
+++ b/packages/web-components/src/search/components/search-bar.ts
@@ -40,9 +40,18 @@ export class SearchBar extends RelewiseLitElement {
         }
     }
 
+    blurSearchInput() {
+        const searchInput = this.shadowRoot?.getElementById('search-input');
+        if (searchInput) {
+            searchInput.blur();
+        }
+    }
+
     render() {
         return html`
-        <div class="rw-search-bar rw-border" part="input">
+        <div class="rw-search-bar rw-border" part="input"
+            @pointerdown=${() => this.setSearchBarInFocus(true)}
+            @touchstart=${() => this.setSearchBarInFocus(true)}>
             <input
                 id="search-input"
                 autocomplete="off"

--- a/packages/web-components/src/search/product-search-overlay.ts
+++ b/packages/web-components/src/search/product-search-overlay.ts
@@ -166,7 +166,7 @@ export class ProductSearchOverlay extends RelewiseLitElement {
 
     closeSearchKeyboard() {
         this.resultBoxIsHovered = true;
-        const searchBar = this.shadowRoot?.querySelector('relewise-search-bar');
+        const searchBar = this.renderRoot.querySelector('relewise-search-bar');
         searchBar?.blurSearchInput();
     }
 

--- a/packages/web-components/src/search/product-search-overlay.ts
+++ b/packages/web-components/src/search/product-search-overlay.ts
@@ -117,6 +117,12 @@ export class ProductSearchOverlay extends RelewiseLitElement {
     }
 
     handleKeyDown(event: KeyboardEvent): void {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            this.closeOverlay();
+            return;
+        }
+
         if (!this.results) {
             return;
         }
@@ -144,6 +150,12 @@ export class ProductSearchOverlay extends RelewiseLitElement {
                 this.handleActionOnResult(this.results[this.selectedIndex]);
                 break;
         }
+    }
+
+    closeOverlay() {
+        this.searchBarInFocus = false;
+        this.resultBoxIsHovered = false;
+        this.renderRoot.querySelector('relewise-search-bar')?.blurSearchInput();
     }
 
     setSearchBarInFocus(inFocus: boolean) {

--- a/packages/web-components/src/search/product-search-overlay.ts
+++ b/packages/web-components/src/search/product-search-overlay.ts
@@ -67,13 +67,34 @@ export class ProductSearchOverlay extends RelewiseLitElement {
     user: User | null = null;
 
     private debounceTimeoutHandlerId: ReturnType<typeof setTimeout> | null = null;
+    private blurTimeoutHandlerId: ReturnType<typeof setTimeout> | null = null;
     private abortController = new AbortController();
+    private readonly handleDocumentPointerDown = (event: Event) => {
+        if (event.composedPath().includes(this)) {
+            return;
+        }
+
+        if (this.blurTimeoutHandlerId) {
+            clearTimeout(this.blurTimeoutHandlerId);
+            this.blurTimeoutHandlerId = null;
+        }
+        this.searchBarInFocus = false;
+        this.resultBoxIsHovered = false;
+    };
 
     async connectedCallback() {
         if (!this.displayedAtLocation) {
             console.error('No displayedAtLocation defined!');
         }
         super.connectedCallback();
+        document.addEventListener('pointerdown', this.handleDocumentPointerDown, true);
+        document.addEventListener('touchstart', this.handleDocumentPointerDown, true);
+    }
+
+    disconnectedCallback() {
+        document.removeEventListener('pointerdown', this.handleDocumentPointerDown, true);
+        document.removeEventListener('touchstart', this.handleDocumentPointerDown, true);
+        super.disconnectedCallback();
     }
 
     setSearchTerm(term: string) {
@@ -123,6 +144,30 @@ export class ProductSearchOverlay extends RelewiseLitElement {
                 this.handleActionOnResult(this.results[this.selectedIndex]);
                 break;
         }
+    }
+
+    setSearchBarInFocus(inFocus: boolean) {
+        if (inFocus) {
+            if (this.blurTimeoutHandlerId) {
+                clearTimeout(this.blurTimeoutHandlerId);
+                this.blurTimeoutHandlerId = null;
+            }
+            this.searchBarInFocus = true;
+            return;
+        }
+
+        this.blurTimeoutHandlerId = setTimeout(() => {
+            this.blurTimeoutHandlerId = null;
+            if (!this.resultBoxIsHovered) {
+                this.searchBarInFocus = false;
+            }
+        });
+    }
+
+    closeSearchKeyboard() {
+        this.resultBoxIsHovered = true;
+        const searchBar = this.shadowRoot?.querySelector('relewise-search-bar');
+        searchBar?.blurSearchInput();
     }
 
     redirectToSearchPage(termOverride?: string): boolean {
@@ -275,7 +320,7 @@ export class ProductSearchOverlay extends RelewiseLitElement {
                 exportparts="input: searchbar-input, icon: searchbar-icon"
                 .term=${this.term}
                 .setSearchTerm=${(term: string) => this.setSearchTerm(term)}
-                .setSearchBarInFocus=${(inFocus: boolean) => this.searchBarInFocus = inFocus}
+                .setSearchBarInFocus=${(inFocus: boolean) => this.setSearchBarInFocus(inFocus)}
                 .placeholder=${localization?.searchBar?.placeholder ?? 'Search'}
                 .handleKeyEvent=${(e: KeyboardEvent) => this.handleKeyDown(e)}
                 .autofocus="${this.autofocus}"
@@ -293,6 +338,7 @@ export class ProductSearchOverlay extends RelewiseLitElement {
                     .redirectToSearchPage=${(term?: string) => this.redirectToSearchPage(term)}
                     .noResultsMessage=${localization?.searchResults?.noResults ?? 'No products found'}
                     .setResultOverlayHovered=${(hovered: boolean) => this.resultBoxIsHovered = hovered}
+                    .closeSearchKeyboard=${() => this.closeSearchKeyboard()}
                     .hits=${this.productSearchResultHits}
                     .user=${this.user}
                     .navigateOnSuggestion=${this.navigateOnSuggestion}>

--- a/packages/web-components/src/search/product-search-overlay.ts
+++ b/packages/web-components/src/search/product-search-overlay.ts
@@ -58,6 +58,9 @@ export class ProductSearchOverlay extends RelewiseLitElement {
     resultBoxIsHovered: boolean = false;
 
     @state()
+    overlayIsClosed: boolean = false;
+
+    @state()
     hasCompletedSearchRequest: boolean = false;
 
     @state()
@@ -104,8 +107,11 @@ export class ProductSearchOverlay extends RelewiseLitElement {
         if (!term) {
             this.results = null;
             this.hasCompletedSearchRequest = false;
+            this.overlayIsClosed = false;
             return;
         }
+
+        this.overlayIsClosed = false;
 
         if (this.debounceTimeoutHandlerId) {
             clearTimeout(this.debounceTimeoutHandlerId);
@@ -155,6 +161,7 @@ export class ProductSearchOverlay extends RelewiseLitElement {
     closeOverlay() {
         this.searchBarInFocus = false;
         this.resultBoxIsHovered = false;
+        this.overlayIsClosed = true;
         this.renderRoot.querySelector('relewise-search-bar')?.blurSearchInput();
     }
 
@@ -164,6 +171,7 @@ export class ProductSearchOverlay extends RelewiseLitElement {
                 clearTimeout(this.blurTimeoutHandlerId);
                 this.blurTimeoutHandlerId = null;
             }
+            this.overlayIsClosed = false;
             this.searchBarInFocus = true;
             return;
         }
@@ -326,6 +334,11 @@ export class ProductSearchOverlay extends RelewiseLitElement {
 
     render() {
         const localization = getRelewiseUISearchOptions()?.localization;
+        const shouldShowOverlay = !this.overlayIsClosed &&
+            this.hasCompletedSearchRequest &&
+            this.term &&
+            (this.searchBarInFocus || this.resultBoxIsHovered);
+
         return html`
             <relewise-search-bar 
                 part="searchbar"
@@ -337,10 +350,7 @@ export class ProductSearchOverlay extends RelewiseLitElement {
                 .handleKeyEvent=${(e: KeyboardEvent) => this.handleKeyDown(e)}
                 .autofocus="${this.autofocus}"
                 ></relewise-search-bar>    
-            ${(this.searchBarInFocus &&
-                this.hasCompletedSearchRequest &&
-                this.term) ||
-                this.resultBoxIsHovered ?
+            ${shouldShowOverlay ?
                 html`<relewise-product-search-overlay-results
                     part="overlay"
                     exportparts="overlay: overlay-container, title: overlay-title"

--- a/packages/web-components/tests/productSearchOverlay.test.ts
+++ b/packages/web-components/tests/productSearchOverlay.test.ts
@@ -161,6 +161,25 @@ suite('product search overlay', () => {
         assert.exists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
     });
 
+    test('does not reopen no-results overlay from stale hover after Escape', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        el.handleKeyDown(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+        await el.updateComplete;
+
+        el.results = null;
+        el.resultBoxIsHovered = true;
+        await el.updateComplete;
+
+        assert.notExists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+
     test('closes the search keyboard when touching and scrolling light DOM results', async() => {
         const options = mockRelewiseOptions();
         options.components = {

--- a/packages/web-components/tests/productSearchOverlay.test.ts
+++ b/packages/web-components/tests/productSearchOverlay.test.ts
@@ -101,6 +101,66 @@ suite('product search overlay', () => {
         assert.exists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
     });
 
+    test('closes results and blurs input on Escape', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        const searchBar = el.shadowRoot!.querySelector('relewise-search-bar')!;
+        await searchBar.updateComplete;
+        const input = searchBar.shadowRoot!.querySelector('input')!;
+        input.focus();
+
+        const event = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true });
+        el.handleKeyDown(event);
+        await el.updateComplete;
+
+        assert.isTrue(event.defaultPrevented);
+        assert.notEqual(searchBar.shadowRoot!.activeElement, input);
+        assert.notExists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+
+    test('closes no-results overlay on Escape', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = null;
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        const event = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true });
+        el.handleKeyDown(event);
+        await el.updateComplete;
+
+        assert.isTrue(event.defaultPrevented);
+        assert.notExists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+
+    test('reopens results after Escape when the input receives focus again', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        el.handleKeyDown(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+        await el.updateComplete;
+
+        const searchBar = el.shadowRoot!.querySelector('relewise-search-bar')!;
+        await searchBar.updateComplete;
+        searchBar.shadowRoot!.querySelector('input')!.focus();
+        await el.updateComplete;
+
+        assert.exists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+
     test('closes the search keyboard when touching and scrolling light DOM results', async() => {
         const options = mockRelewiseOptions();
         options.components = {

--- a/packages/web-components/tests/productSearchOverlay.test.ts
+++ b/packages/web-components/tests/productSearchOverlay.test.ts
@@ -100,4 +100,31 @@ suite('product search overlay', () => {
         assert.equal(blurCalls, 1);
         assert.exists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
     });
+
+    test('closes the search keyboard when touching and scrolling light DOM results', async() => {
+        const options = mockRelewiseOptions();
+        options.components = {
+            domMode: 'light',
+        };
+        initializeRelewiseUI(options).useSearch();
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        const searchBar = el.querySelector('relewise-search-bar')!;
+        let blurCalls = 0;
+        searchBar.blurSearchInput = () => blurCalls++;
+
+        const results = el.querySelector('relewise-product-search-overlay-results')!;
+        await (results as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
+        results.querySelector('.rw-result-container')!.dispatchEvent(new Event('touchmove', { bubbles: true, composed: true }));
+        await el.updateComplete;
+
+        assert.equal(blurCalls, 1);
+        assert.exists(el.querySelector('relewise-product-search-overlay-results'));
+    });
 });

--- a/packages/web-components/tests/productSearchOverlay.test.ts
+++ b/packages/web-components/tests/productSearchOverlay.test.ts
@@ -1,0 +1,103 @@
+import { assert, fixture, html } from '@open-wc/testing';
+import { initializeRelewiseUI, ProductSearchOverlay } from '../src';
+import { mockRelewiseOptions } from './util/mockRelewiseUIOptions';
+
+suite('product search overlay', () => {
+    setup(() => {
+        initializeRelewiseUI(mockRelewiseOptions()).useSearch();
+    });
+
+    test('keeps results open when the search input blurs after touching the overlay', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        const results = el.shadowRoot!.querySelector('relewise-product-search-overlay-results')!;
+        await (results as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
+        results.shadowRoot!.querySelector('.rw-result-container')!.dispatchEvent(new Event('touchstart', { bubbles: true, composed: true }));
+        el.setSearchBarInFocus(false);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await el.updateComplete;
+
+        assert.exists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+
+    test('closes results after touching outside the overlay', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        el.resultBoxIsHovered = true;
+        await el.updateComplete;
+
+        document.body.dispatchEvent(new Event('touchstart', { bubbles: true, composed: true }));
+        await el.updateComplete;
+
+        assert.notExists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+
+    test('reopens existing results when touching the search bar after touching outside', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        document.body.dispatchEvent(new Event('touchstart', { bubbles: true, composed: true }));
+        await el.updateComplete;
+
+        const searchBar = el.shadowRoot!.querySelector('relewise-search-bar')!;
+        await (searchBar as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
+        searchBar.shadowRoot!.querySelector('.rw-search-bar')!.dispatchEvent(new Event('touchstart', { bubbles: true, composed: true }));
+        await el.updateComplete;
+
+        assert.exists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+
+    test('does not close results from a pending blur after focus returns', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        el.setSearchBarInFocus(false);
+        el.setSearchBarInFocus(true);
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await el.updateComplete;
+
+        assert.exists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+
+    test('closes the search keyboard when touching and scrolling results', async() => {
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        el.term = 'shoe';
+        el.hasCompletedSearchRequest = true;
+        el.results = [{ searchTermPrediction: { term: 'shoes' } as any }];
+        el.searchBarInFocus = true;
+        await el.updateComplete;
+
+        const searchBar = el.shadowRoot!.querySelector('relewise-search-bar')!;
+        let blurCalls = 0;
+        searchBar.blurSearchInput = () => blurCalls++;
+
+        const results = el.shadowRoot!.querySelector('relewise-product-search-overlay-results')!;
+        await (results as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete;
+        results.shadowRoot!.querySelector('.rw-result-container')!.dispatchEvent(new Event('touchmove', { bubbles: true, composed: true }));
+        await el.updateComplete;
+
+        assert.equal(blurCalls, 1);
+        assert.exists(el.shadowRoot!.querySelector('relewise-product-search-overlay-results'));
+    });
+});


### PR DESCRIPTION
https://trello.com/c/O2mSkhry/21203-hobbii-keep-search-overlay-open-when-dismissing-the-ios-keyboard

## What changed
- Keep the product search overlay open during touch interactions with the result list.
- Dismiss the iOS keyboard when the user starts scrolling overlay results by blurring the search input from the touch gesture.
- Reopen cached overlay results when the search bar is touched again after an outside close.
- Add browser regression tests for the touch/blur/outside-touch flows.

## Why
On iOS, scrolling the overlay can blur the input and close the overlay because touch interactions do not behave like desktop hover. Closing the keyboard ourselves when result scrolling starts avoids the keyboard fighting the overlay scroll while preserving the visible results.

## Validation
- `npx wtr --config web-test-runner-config.mjs tests/productSearchOverlay.test.ts`
- `npm run build`
- `npm run build:types`
- `npm run test`