### PR TITLE
Support relative product search redirect URLs

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -621,6 +621,7 @@ This component renders a search bar that will [search for products](https://docs
 
 Search Redirects is supported in the product search overlay, by default we redirect the user on "Enter", when a Redirect matches the search term.
 If you want the Redirects listed as suggestions, you can add a "Title" data entry on the Redirect to get them shown.
+Redirect destinations can be absolute URLs or relative URLs resolved against the current page.
 
 ```html
 <relewise-product-search-overlay displayed-at-location="LOCATION"></relewise-product-search-overlay>

--- a/packages/web-components/src/search/product-search-overlay.ts
+++ b/packages/web-components/src/search/product-search-overlay.ts
@@ -254,7 +254,7 @@ export class ProductSearchOverlay extends RelewiseLitElement {
         } else if (result?.redirect) {
             // We have previously validated the destination as a valid URL.
             window.location.href = result?.redirect.destination ?? '';
-        } else if (this.redirects && this.redirects.length > 0 && URL.canParse(this.redirects[0].destination ?? '')) {
+        } else if (this.redirects && this.redirects.length > 0 && canParseRedirectDestination(this.redirects[0].destination)) {
             if (this.redirects[0].destination) {
                 window.location.href = this.redirects[0].destination;
             }
@@ -299,7 +299,7 @@ export class ProductSearchOverlay extends RelewiseLitElement {
                 return { product };
             }) ?? [];
             this.redirects = productSearchResult.redirects;
-            const redirects: SearchResult[] = productSearchResult.redirects?.filter(x => x.data?.Title && URL.canParse(x.destination ?? '')).map(x => ({ redirect: x })) ?? [];
+            const redirects: SearchResult[] = productSearchResult.redirects?.filter(x => x.data?.Title && canParseRedirectDestination(x.destination)).map(x => ({ redirect: x })) ?? [];
 
             let searchTermPredictions: SearchResult[] = [];
             const searchTermPredictionResponse = findResponseOfType<SearchTermPredictionResponse>(response.responses, 'SearchTermPredictionResponse');
@@ -392,6 +392,12 @@ function isResponseWithType(response: any, typeName: string): boolean {
 function findResponseOfType<T>(responses: any[] | undefined, typeName: string): T | undefined {
     if (!responses) return undefined;
     return responses.find(r => isResponseWithType(r, typeName)) as T | undefined;
+}
+
+function canParseRedirectDestination(destination?: string | null): boolean {
+    if (!destination) return false;
+
+    return URL.canParse(destination) || URL.canParse(destination, window.location.href);
 }
 
 declare global {

--- a/packages/web-components/tests/productSearchOverlay.test.ts
+++ b/packages/web-components/tests/productSearchOverlay.test.ts
@@ -1,10 +1,53 @@
 import { assert, fixture, html } from '@open-wc/testing';
+import { Searcher } from '@relewise/client';
 import { initializeRelewiseUI, ProductSearchOverlay } from '../src';
 import { mockRelewiseOptions } from './util/mockRelewiseUIOptions';
 
 suite('product search overlay', () => {
+    const originalBatch = Searcher.prototype.batch;
+
     setup(() => {
         initializeRelewiseUI(mockRelewiseOptions()).useSearch();
+    });
+
+    teardown(() => {
+        Searcher.prototype.batch = originalBatch;
+    });
+
+    test('includes redirects with relative destinations in the results', async() => {
+        Searcher.prototype.batch = async function() {
+            return {
+                responses: [
+                    {
+                        hits: 0,
+                        results: [],
+                        redirects: [
+                            { destination: '/campaign', data: { Title: 'Campaign' } },
+                            { destination: 'https://example.com/campaign', data: { Title: 'External campaign' } },
+                            { destination: 'https://[invalid', data: { Title: 'Invalid' } },
+                        ],
+                    },
+                    { $type: 'SearchTermPredictionResponse', predictions: [] },
+                    { $type: 'ProductCategorySearchResponse', results: [] },
+                ],
+            } as any;
+        };
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+
+        await el.search('campaign');
+
+        assert.deepEqual(el.results?.map(result => result.redirect?.destination), ['/campaign', 'https://example.com/campaign']);
+    });
+
+    test('uses a relative redirect destination when submitting the matching term', async() => {
+        const originalUrl = window.location.href;
+        const el = await fixture<ProductSearchOverlay>(html`<relewise-product-search-overlay></relewise-product-search-overlay>`);
+        el.redirects = [{ destination: '#campaign' } as any];
+
+        el.handleActionOnResult();
+
+        assert.equal(window.location.hash, '#campaign');
+        window.history.replaceState({}, document.title, originalUrl);
     });
 
     test('keeps results open when the search input blurs after touching the overlay', async() => {


### PR DESCRIPTION
[Trello card](https://trello.com/c/9X62UTfN/21282-reconsider-the-web-components-redirect-safeguard)

## What changed

- Allow product-search overlay redirects to use relative destinations resolved by the browser against the current page.
- Preserve absolute destinations exactly as provided, including external support or documentation URLs.
- Apply the same validation to displayed redirect suggestions and Enter-key redirects.
- Document the supported destination formats and add regression coverage.

## Why

The overlay previously called `URL.canParse` without a base URL, which rejected otherwise valid relative destinations. Consumers therefore had to configure absolute URLs even for same-site redirects.

## Impact

Existing absolute redirects remain unchanged. Relative paths and fragments are now accepted, while malformed destinations continue to be excluded.

## Validation

- `npm run build`
- `npm run build:types`
- `npm run test` (63 tests passed in Chromium, Firefox, and WebKit)